### PR TITLE
Primitive to Proto and Proto to Primitive Issues

### DIFF
--- a/hdl21/primitives.py
+++ b/hdl21/primitives.py
@@ -474,6 +474,29 @@ _add(
 
 
 @paramclass
+class SineVoltageSourceParams:
+    """`SineVoltageSource` Parameters"""
+
+    voff = Param(dtype=Optional[Prefixed], default=None, desc="Offset (V)")
+    vamp = Param(dtype=Optional[Prefixed], default=None, desc="Amplitude (V)")
+    freq = Param(dtype=Optional[Prefixed], default=None, desc="Frequency (Hz)")
+    td = Param(dtype=Optional[Prefixed], default=None, desc="Delay (s)")
+    phase = Param(dtype=Optional[Prefixed], default=None, desc="Phase at td (degrees)")
+
+
+_add(
+    prim=Primitive(
+        name="SineVoltageSource",
+        desc="Sine Voltage Source",
+        port_list=copy.deepcopy(PassivePorts),
+        paramtype=SineVoltageSourceParams,
+        primtype=PrimitiveType.IDEAL,
+    ),
+    aliases=["Vsin"],
+)
+
+
+@paramclass
 class CurrentSourceParams:
     dc = Param(dtype=Optional[Prefixed], default=0, desc="DC Value (A)")
 

--- a/hdl21/primitives.py
+++ b/hdl21/primitives.py
@@ -428,8 +428,8 @@ Sources
 class DcVoltageSourceParams:
     """`DcVoltageSource` Parameters"""
 
-    dc = Param(dtype=Optional[Prefixed], default=0, desc="DC Value (V)")
-    ac = Param(dtype=Optional[Prefixed], default=None, desc="AC Amplitude (V)")
+    dc = Param(dtype=Optional[Prefixed], default=0 * Prefix.UNIT, desc="DC Value (V)")
+    ac = Param(dtype=Optional[Prefixed], default=0 * Prefix.UNIT, desc="AC Amplitude (V)")
 
 
 _add(

--- a/hdl21/proto/from_proto.py
+++ b/hdl21/proto/from_proto.py
@@ -229,6 +229,7 @@ def import_vlsir_primitive(pref: vlsir.utils.QualifiedName) -> Primitive:
     prim_map = {
         "vdc": "DcVoltageSource",
         "vpulse": "PulseVoltageSource",
+        "vsin": "SineVoltageSource",
         "isource": "CurrentSource",
         "resistor": "IdealResistor",
         "capacitor": "IdealCapacitor",

--- a/hdl21/proto/from_proto.py
+++ b/hdl21/proto/from_proto.py
@@ -227,11 +227,15 @@ def import_vlsir_primitive(pref: vlsir.utils.QualifiedName) -> Primitive:
     # FIXME: specialized importing of their parameters!
     prim_map = {
         "vdc": "DcVoltageSource",
-        "vpluse": "PulseVoltageSource",
+        "vpulse": "PulseVoltageSource",
         "isource": "CurrentSource",
         "resistor": "IdealResistor",
         "capacitor": "IdealCapacitor",
         "inductor": "IdealInductor",
+        "vcvs": "VoltageControlledVoltageSource",
+        "vccs": "VoltageControlledCurrentSource",
+        "ccvs": "CurrentControlledVoltageSource",
+        "cccs": "CurrentControlledCurrentSource",
     }
     if pref.name not in prim_map:
         msg = f"Invalid or unsupported VLSIR Primitive: {pref.name}"

--- a/hdl21/proto/from_proto.py
+++ b/hdl21/proto/from_proto.py
@@ -2,7 +2,7 @@
 hdl21 ProtoBuf Import 
 """
 from types import SimpleNamespace
-from typing import Union, Any, Dict, List
+from typing import Union, Any, Dict, List, Optional
 
 # Local imports
 # Proto-definitions
@@ -18,7 +18,7 @@ from ..signal import Signal, PortDir, Visibility
 from ..slice import Slice
 from ..concat import Concat
 from .. import primitives
-from ..primitives import Primitive
+from ..primitives import Primitive, Vpulse
 
 
 def from_proto(pkg: vckt.Package) -> SimpleNamespace:
@@ -155,7 +155,8 @@ class ProtoImporter:
             if ref.external.domain == "vlsir.primitives":
                 # Import a VLSIR primitive to an ideal element, and convert its parameters
                 target = import_vlsir_primitive(ref.external)
-                params = target.Params(**params)
+                remapped_params = import_primitive_params(target, params)
+                params = target.Params(**remapped_params)
 
             elif ref.external.domain in (
                 "hdl21.primitives",
@@ -370,3 +371,22 @@ def import_prefixed(vpref: vlsir.Prefixed) -> Prefixed:
         raise ValueError(f"Invalid Parameter Type: `{ptype}`")
 
     return Prefixed(prefix=prefix, number=number)
+
+
+def import_primitive_params(target: Primitive, params: Any) -> Dict[str, Optional[Prefixed]]:
+    """Convert the parameters of an `IDEAL` VLSIR element into a primtive form.
+    Returns the result as a dictionary of {name: value}s."""
+
+    if target is Vpulse:
+        return dict(
+            v1=params["v1"],
+            v2=params["v2"],
+            delay=params["td"],
+            rise=params["tr"],
+            fall=params["tf"],
+            width=params["tpw"],
+            period=params["tper"],
+        )
+
+    return params
+

--- a/hdl21/proto/to_proto.py
+++ b/hdl21/proto/to_proto.py
@@ -191,6 +191,10 @@ class ProtoExporter:
                         "IdealResistor": "resistor",
                         "IdealCapacitor": "capacitor",
                         "IdealInductor": "inductor",
+                        "VoltageControlledVoltageSource": "vcvs",
+                        "CurrentControlledVoltageSource": "ccvs",
+                        "VoltageControlledCurrentSource": "vccs",
+                        "CurrentControlledCurrentSource": "cccs",
                     }
                     if call.prim.name not in prim_map:
                         msg = f"Invalid Primitive {call.prim.name} in PrimitiveCall {inst.name}"

--- a/hdl21/proto/to_proto.py
+++ b/hdl21/proto/to_proto.py
@@ -187,6 +187,7 @@ class ProtoExporter:
                     prim_map = {
                         "DcVoltageSource": "vdc",
                         "PulseVoltageSource": "vpulse",
+                        "SineVoltageSource": "vsin",
                         "CurrentSource": "isource",
                         "IdealResistor": "resistor",
                         "IdealCapacitor": "capacitor",

--- a/hdl21/tests/test_exports.py
+++ b/hdl21/tests/test_exports.py
@@ -112,6 +112,11 @@ def test_ideal_primitives():
             v2=0*h.prefix.m, period=0*h.prefix.m, 
             rise=0*h.prefix.m, fall=0*h.prefix.m, width=0*h.prefix.m)
         vpu = h.Vpulse(_vpu)(p=p, n=n)
+        _vsin = h.Vsin.Params(
+            voff=0*h.prefix.m, vamp=0*h.prefix.m, 
+            freq=0*h.prefix.m, td=0*h.prefix.m, 
+            phase=0*h.prefix.m)
+        vsin = h.Vsin(_vsin)(p=p, n=n)
         _idc = h.Idc.Params(dc=0*h.prefix.m)
         idc = h.Idc(_idc)(p=p, n=n)
         _vcvs = h.Vcvs.Params(gain=1*h.prefix.m)

--- a/hdl21/tests/test_exports.py
+++ b/hdl21/tests/test_exports.py
@@ -84,6 +84,50 @@ def test_prim_proto1():
         assert isinstance(inst._resolved, h.primitives.PrimitiveCall)
 
 
+def test_ideal_primitives():
+    # Test round-tripping ideal primitives
+
+    @h.module
+    class HasPrims:
+        p = h.Signal()
+        n = h.Signal()
+        p2 = h.Signal()
+        n2 = h.Signal()
+
+        # Wire up a bunch of two-terminal primitives in parallel
+        _rp = h.R.Params(r=50)
+        r = h.Resistor(_rp)(p=p, n=n)
+        _cp = h.C.Params(c=1e-12)
+        c = h.Capacitor(_cp)(p=p, n=n)
+        _lp = h.L.Params(l=1e-15)
+        l = h.Inductor(_lp)(p=p, n=n)
+        _dp = h.D.Params()
+        d = h.Diode(_dp)(p=p, n=n)
+        _sp = h.Short.Params()
+        s = h.Short(_sp)(p=p, n=n)
+        _vdc = h.Vdc.Params(dc=0*h.prefix.m, ac=0*h.prefix.m)
+        vdc = h.Vdc(_vdc)(p=p, n=n)
+        _vpu = h.Vpulse.Params(
+            delay=0*h.prefix.m, v1=0*h.prefix.m, 
+            v2=0*h.prefix.m, period=0*h.prefix.m, 
+            rise=0*h.prefix.m, fall=0*h.prefix.m, width=0*h.prefix.m)
+        vpu = h.Vpulse(_vpu)(p=p, n=n)
+        _idc = h.Idc.Params(dc=0*h.prefix.m)
+        idc = h.Idc(_idc)(p=p, n=n)
+        _vcvs = h.Vcvs.Params(gain=1*h.prefix.m)
+        vcvs = h.Vcvs(_vcvs)(p=p, n=n, cp=p2, cn=n2)
+        _ccvs = h.Ccvs.Params(gain=1*h.prefix.m)
+        ccvs = h.Ccvs(_ccvs)(p=p, n=n, cp=p2, cn=n2)
+        _vccs = h.Vccs.Params(gain=1*h.prefix.m)
+        vccs = h.Vccs(_vccs)(p=p, n=n, cp=p2, cn=n2)
+        _cccs = h.Cccs.Params(gain=1*h.prefix.m)
+        cccs = h.Cccs(_cccs)(p=p, n=n, cp=p2, cn=n2)
+
+
+    ppkg = h.to_proto(HasPrims)
+    ns = h.from_proto(ppkg)
+
+
 def test_proto1():
     # First Proto-export test
 


### PR DESCRIPTION
Probably not ready to merge yet.

I added a test that checks that all our Hdl21 primitives can actually be exported to protos, and can be imported back from protos. 

The import does not work, because the proto names for parameters differs from the hdl21 name for the same parameters. How do we want to deal with this? 