### PR TITLE
Full suite of `Prefixed` Math Operations

### DIFF
--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -15,8 +15,6 @@ with the multiplication operator, to construct values such as `11 * e(-21)`.
 
 """
 
-import math
-
 from enum import Enum
 from decimal import Decimal
 from typing import Optional, Any

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -23,6 +23,7 @@ from typing import Optional, Any
 
 EPSILON = 20
 
+
 class Prefix(Enum):
     """Enumerated Unit Prefixes
     Values are equal to the associated power-of-ten exponent."""
@@ -59,9 +60,7 @@ class Prefix(Enum):
 
     @classmethod
     def closest(cls, exp: Any) -> Optional["Prefix"]:
-        return min(
-            cls.__members__.values(), key=lambda x: abs(x.value - exp)
-        )
+        return min(cls.__members__.values(), key=lambda x: abs(x.value - exp))
 
     def __mul__(self, other: Any):
 

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -53,12 +53,12 @@ class Prefix(Enum):
         """Get the prefix from the exponent. If `exp` is not
         in the members of Prefix, returns None instead"""
         inverted = {v.value: v for v in cls.__members__.values()}
-        
+
         return inverted.get(exp, None)
 
     @classmethod
     def closest(cls, exp: Any) -> Optional["Prefix"]:
-        return min(cls.__members__.values(), key = lambda x: abs(x.value-exp))
+        return min(cls.__members__.values(), key=lambda x: abs(x.value - exp))
 
     def __mul__(self, other: Any):
 
@@ -96,7 +96,7 @@ class Prefix(Enum):
         if isinstance(other, Prefix):
 
             # Prefix divided by Prefix, eg. `p / M == a`
-            targ = self.value - other.value          
+            targ = self.value - other.value
             return e(targ)
 
         return NotImplemented
@@ -109,9 +109,8 @@ class Prefix(Enum):
             # Prefix raised to power of number, eg. `µ ** 4 == y`
             targ = self.value * other
             return e(targ)
-        
-        return NotImplemented
 
+        return NotImplemented
 
 
 """
@@ -164,11 +163,11 @@ class Prefixed:
     prefix: Prefix = Prefix.UNIT  # Enumerated SI Prefix. Defaults to unity.
 
     def __int__(self) -> int:
-        return int(self.number) * 10 ** self.prefix.value
+        return int(self.number) * 10**self.prefix.value
 
     def __float__(self) -> float:
         """Convert to float"""
-        return float(self.number) * 10 ** self.prefix.value
+        return float(self.number) * 10**self.prefix.value
 
     def __mul__(self, other) -> "Prefixed":
         if isinstance(other, Prefixed):
@@ -194,7 +193,7 @@ class Prefixed:
     def __pow__(self, other) -> "Prefixed":
         if not isinstance(other, (int, float, Decimal)):
             return NotImplemented
-        return ((self.number ** Decimal(other)) * (self.prefix ** other)).scale()
+        return ((self.number ** Decimal(other)) * (self.prefix**other)).scale()
 
     def __add__(self, other: "Prefixed") -> "Prefixed":
         return _add(lhs=self, rhs=other).scale()
@@ -208,7 +207,7 @@ class Prefixed:
     def __rsub__(self, other: "Prefixed") -> "Prefixed":
         return _subtract(lhs=other, rhs=self).scale()
 
-    def scale(self, prefix : Prefix = None) -> "Prefixed":
+    def scale(self, prefix: Prefix = None) -> "Prefixed":
         """Scale to a new `Prefix`"""
         if isinstance(prefix, Prefix):
             newnum = self.number * Decimal(10) ** (self.prefix.value - prefix.value)
@@ -222,29 +221,28 @@ class Prefixed:
 
     # Comparison operators that respect class convention
     def __lt__(self, other) -> bool:
-        lhs,rhs = _scale_to_smaller(self,other)
+        lhs, rhs = _scale_to_smaller(self, other)
         return lhs.number < rhs.number
 
     def __le__(self, other) -> bool:
-        lhs,rhs = _scale_to_smaller(self,other)
+        lhs, rhs = _scale_to_smaller(self, other)
         return lhs.number <= rhs.number
 
     def __eq__(self, other) -> bool:
-        lhs,rhs = _scale_to_smaller(self,other)
+        lhs, rhs = _scale_to_smaller(self, other)
         return lhs.number == rhs.number
-    
-    def __ne__(self,other) -> bool:
-        lhs,rhs = _scale_to_smaller(self,other)
+
+    def __ne__(self, other) -> bool:
+        lhs, rhs = _scale_to_smaller(self, other)
         return lhs.number != rhs.number
 
-    def __gt__(self,other) -> bool:
-        lhs,rhs = _scale_to_smaller(self,other)
+    def __gt__(self, other) -> bool:
+        lhs, rhs = _scale_to_smaller(self, other)
         return lhs.number > rhs.number
 
-    def __ge__(self,other) -> bool:
-        lhs,rhs = _scale_to_smaller(self,other)
+    def __ge__(self, other) -> bool:
+        lhs, rhs = _scale_to_smaller(self, other)
         return lhs.number >= rhs.number
-
 
 
 def _add(lhs: Prefixed, rhs: Prefixed) -> Prefixed:
@@ -274,13 +272,16 @@ def _subtract(lhs: Prefixed, rhs: Prefixed) -> Prefixed:
     newnum = lhs.scale(smaller).number - rhs.scale(smaller).number
     return Prefixed(newnum, smaller)
 
-def _scale_to_smaller(lhs: Prefixed, rhs: Prefixed) -> tuple[Prefixed, Prefixed]:
+
+def _scale_to_smaller(lhs: Prefixed, rhs: Prefixed):
     smaller = lhs.prefix if lhs.prefix.value < rhs.prefix.value else rhs.prefix
     return lhs.scale(smaller), rhs.scale(smaller)
 
-def _epsilon_equiv(lhs: Prefixed,rhs: Prefixed,epsilon):
-    lhs, rhs = _scale_to_smaller(lhs,rhs)
-    return round(lhs.number,epsilon) == round(rhs.number,epsilon)
+
+def _epsilon_equiv(lhs: Prefixed, rhs: Prefixed, epsilon):
+    lhs, rhs = _scale_to_smaller(lhs, rhs)
+    return round(lhs.number, epsilon) == round(rhs.number, epsilon)
+
 
 # Common prefixes as single-character identifiers, and exposed in the module namespace.
 y = YOCTO = Prefix.YOCTO
@@ -307,6 +308,7 @@ Y = YOTTA = Prefix.YOTTA
 # but is exposed at module scope.
 UNIT = Prefix.UNIT
 
+
 @dataclass
 class Exponent:
     """
@@ -318,31 +320,34 @@ class Exponent:
     A important feature of the design of Exponent is that it is a helper class: so it may
     only be invoked by other classes and can only interact with itself and Decimal/int/floats.
     """
-    symbol : Prefix # Prefix symbol for calculation
-    residual : Decimal = Decimal(0) # Prefix
+
+    symbol: Prefix  # Prefix symbol for calculation
+    residual: Decimal = Decimal(0)  # Prefix
 
     @classmethod
-    def from_exp(self, exp : Any):
+    def from_exp(self, exp: Any):
 
         out_symbol = Prefix.closest(exp)
         out_residual = exp - out_symbol.value
         return Exponent(out_symbol, out_residual)
 
-    def __mul__(self,other : Optional["Exponent"]) -> Optional["Exponent"]:
+    def __mul__(self, other: Optional["Exponent"]) -> Optional["Exponent"]:
 
         if isinstance(other, Exponent):
             # Exponent(n,0.3) * Exponent(K,0.4) == e(-8.7) * e(3.4) = e(-5.3)
-            return Exponent.from_exp(self.symbol.value + other.symbol.value + self.residual + other.residual)
+            return Exponent.from_exp(
+                self.symbol.value + other.symbol.value + self.residual + other.residual
+            )
 
         return NotImplemented
 
-    def __rmul__(self, other : Any) -> Prefixed:
+    def __rmul__(self, other: Any) -> Prefixed:
 
         if isinstance(other, (int, float, Decimal)):
             # 16 * Exponent(Symbol.UNIT,0.25) == 2 * Prefix.UNIT
 
             out_number = Decimal(other) * Decimal(10) ** self.residual
-            
+
             return Prefixed(out_number, self.symbol)
 
         elif isinstance(other, Prefixed):
@@ -353,26 +358,29 @@ class Exponent:
 
         return NotImplemented
 
-    def __truediv__(self, other : Any) -> Optional["Exponent"]:
+    def __truediv__(self, other: Any) -> Optional["Exponent"]:
 
-        if isinstance(other, (int,float,Decimal)):
+        if isinstance(other, (int, float, Decimal)):
             # Exponent(1) / 2 = Exponent(log(5))
             inv_other = Decimal(1) / other
             return inv_other * self
 
         elif isinstance(other, Exponent):
-            return self * (other ** -1)
+            return self * (other**-1)
 
-    def __pow__(self, other : Any) -> Optional["Exponent"]:
+    def __pow__(self, other: Any) -> Optional["Exponent"]:
 
         if isinstance(other, (int, float, Decimal)):
             # Exponent(0.25) ** 4 == Exponent(1)
-            return Exponent.from_exp(((self.symbol.value + self.residual) * Decimal(other)))
+            return Exponent.from_exp(
+                ((self.symbol.value + self.residual) * Decimal(other))
+            )
 
         return NotImplemented
 
     def __repr__(self) -> str:
         return f"e({self.symbol.value+self.residual})"
+
 
 def e(exp: Any) -> Exponent:
     """# Exponential `Prefix` Creation
@@ -385,8 +393,8 @@ def e(exp: Any) -> Exponent:
     The `e()` function is most commonly useful with multiplication,
     to create "floating point" values such as `11 * e(-9)`.
     """
-    
-    if isinstance(exp, (int,float,Decimal)):
+
+    if isinstance(exp, (int, float, Decimal)):
 
         out_symbol = Prefix.closest(exp)
         out_residual = exp - out_symbol.value
@@ -398,4 +406,4 @@ def e(exp: Any) -> Exponent:
 
 # Star-imports *do not* include the single-character names `µ`, `e`, et al.
 # They can be explicityle imported from `hdl21.prefix` instead.
-__all__ = ["Prefix", "Prefixed"]
+__all__ = ["Prefix", "Prefixed", "Exponent"]

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -79,7 +79,7 @@ class Prefix(Enum):
             prefix = e(targ)
 
             # Scale the other number
-            new_num = other.number * 10 ** (targ - prefix.value)
+            new_num = other.number * Decimal(10) ** (targ - prefix.value)
 
             # And create a corresponding `Prefixed`
             return Prefixed(new_num, prefix)
@@ -208,7 +208,7 @@ class Prefixed:
     def scale(self, prefix = None) -> "Prefixed":
         """Scale to a new `Prefix`"""
         if isinstance(prefix, Prefix):
-            newnum = self.number * 10 ** (self.prefix.value - prefix.value)
+            newnum = self.number * Decimal(10) ** (self.prefix.value - prefix.value)
             return Prefixed(newnum, prefix)
         else:
             newpref = math.log10(self.number) + self.prefix.value

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -172,51 +172,50 @@ class Prefixed:
 
     def __mul__(self, other) -> "Prefixed":
         if isinstance(other, Prefixed):
-            return self.number * other.number * self.prefix * other.prefix
+            return (self.number * other.number * self.prefix * other.prefix).scale()
         elif not isinstance(other, (int, float, Decimal)):
             return NotImplemented
-        return Prefixed(self.number * other, self.prefix)
+        return Prefixed(self.number * other, self.prefix).scale()
 
     def __rmul__(self, other) -> "Prefixed":
         if isinstance(other, Prefixed):
-            return self.number * other.number * self.prefix * other.prefix
+            return (self.number * other.number * self.prefix * other.prefix).scale()
         elif not isinstance(other, (int, float, Decimal)):
             return NotImplemented
-        return Prefixed(self.number * other, self.prefix)
+        return Prefixed(self.number * other, self.prefix).scale()
 
     def __truediv__(self, other) -> "Prefixed":
         if isinstance(other, Prefixed):
-            return (self.number / other.number) * (self.prefix / other.prefix)
+            return ((self.number / other.number) * (self.prefix / other.prefix)).scale()
         elif not isinstance(other, (int, float, Decimal)):
             return NotImplemented
-        return Prefixed(self.number / other, self.prefix)
+        return Prefixed(self.number / other, self.prefix).scale()
 
     def __pow__(self, other) -> "Prefixed":
         if not isinstance(other, (int, float, Decimal)):
             return NotImplemented
-        return (self.number ** Decimal(other)) * (self.prefix ** other)
+        return ((self.number ** Decimal(other)) * (self.prefix ** other)).scale()
 
     def __add__(self, other: "Prefixed") -> "Prefixed":
-        return _add(lhs=self, rhs=other)
+        return _add(lhs=self, rhs=other).scale()
 
     def __radd__(self, other: "Prefixed") -> "Prefixed":
-        return _add(lhs=other, rhs=self)
+        return _add(lhs=other, rhs=self).scale()
 
     def __sub__(self, other: "Prefixed") -> "Prefixed":
-        return _subtract(lhs=self, rhs=other)
+        return _subtract(lhs=self, rhs=other).scale()
 
     def __rsub__(self, other: "Prefixed") -> "Prefixed":
-        return _subtract(lhs=other, rhs=self)
+        return _subtract(lhs=other, rhs=self).scale()
 
-    def scale(self, prefix = None) -> "Prefixed":
+    def scale(self, prefix : Prefix = None) -> "Prefixed":
         """Scale to a new `Prefix`"""
         if isinstance(prefix, Prefix):
             newnum = self.number * Decimal(10) ** (self.prefix.value - prefix.value)
             return Prefixed(newnum, prefix)
         else:
-            newpref = math.log10(self.number) + self.prefix.value
-            return self.scale(e(newpref))
-
+            newpref = Prefix.closest(self.number.log10() + self.prefix.value)
+            return self.scale(newpref)
 
     def __repr__(self) -> str:
         return f"{self.number}*{self.prefix.name}"

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -91,89 +91,98 @@ def test_prefix_from_exp():
     assert h.Prefix.from_exp(21) == h.Prefix.ZETTA
     assert h.Prefix.from_exp(24) == h.Prefix.YOTTA
 
-    # Check autoscaling
-    assert h.Prefix.from_exp(-100) == h.Prefix.YOCTO
-    assert h.Prefix.from_exp(+100) == h.Prefix.YOTTA
-    assert h.Prefix.from_exp(-5) == h.Prefix.MICRO
-    assert h.Prefix.from_exp(+5) == h.Prefix.MEGA
-    assert h.Prefix.from_exp(0.5) == h.Prefix.UNIT
-    assert h.Prefix.from_exp(-1.5) == h.Prefix.CENTI
-
 def test_prefix_mul():
     """Test `Prefix` multiplication."""
-    from hdl21.prefix import µ, M
+    from hdl21.prefix import µ, M, e
 
     assert 5 * µ == 5 * h.Prefix.MICRO
     assert 5 * µ == h.Prefixed(5, h.Prefix.MICRO)
-    assert µ * M == h.Prefix.UNIT
+    assert µ * M == e(0)
     
 
 def test_prefix_div():
     """Test `Prefix` division"""
-    from hdl21.prefix import µ, M
+    from hdl21.prefix import µ, M, e
 
-    assert M / µ == h.Prefix.TERA
-    assert µ / M == h.Prefix.PICO
+    assert M / µ == e(12)
+    assert µ / M == e(-12)
+
 
 def test_prefix_pow():
     """Test `Prefix` exponentiation"""
-    from hdl21.prefix import µ
+    from hdl21.prefix import µ, e
 
-    assert µ ** 2 == h.Prefix.PICO
-    assert µ ** 0.5 == h.Prefix.MILLI
-    assert µ ** -1 == h.Prefix.MEGA
+    assert µ ** 2 == e(-12)
+    assert µ ** 0.5 == e(-3)
+    assert µ ** -1 == e(6)
 
 def test_e():
     """Test the `e` shorthand notation for exponential creation"""
     from hdl21.prefix import e
 
-    assert e(-24) == h.Prefix.YOCTO
-    assert e(-21) == h.Prefix.ZEPTO
-    assert e(-18) == h.Prefix.ATTO
-    assert e(-15) == h.Prefix.FEMTO
-    assert e(-12) == h.Prefix.PICO
-    assert e(-9) == h.Prefix.NANO
-    assert e(-6) == h.Prefix.MICRO
-    assert e(-3) == h.Prefix.MILLI
-    assert e(-2) == h.Prefix.CENTI
-    assert e(-1) == h.Prefix.DECI
-    assert e(1) == h.Prefix.DECA
-    assert e(2) == h.Prefix.HECTO
-    assert e(3) == h.Prefix.KILO
-    assert e(6) == h.Prefix.MEGA
-    assert e(9) == h.Prefix.GIGA
-    assert e(12) == h.Prefix.TERA
-    assert e(15) == h.Prefix.PETA
-    assert e(18) == h.Prefix.EXA
-    assert e(21) == h.Prefix.ZETTA
-    assert e(24) == h.Prefix.YOTTA
+    assert e(-24).symbol == h.Prefix.YOCTO
+    assert e(-21).symbol == h.Prefix.ZEPTO
+    assert e(-18).symbol == h.Prefix.ATTO
+    assert e(-15).symbol == h.Prefix.FEMTO
+    assert e(-12).symbol == h.Prefix.PICO
+    assert e(-9).symbol == h.Prefix.NANO
+    assert e(-6).symbol == h.Prefix.MICRO
+    assert e(-3).symbol == h.Prefix.MILLI
+    assert e(-2).symbol == h.Prefix.CENTI
+    assert e(-1).symbol == h.Prefix.DECI
+    assert e(1).symbol == h.Prefix.DECA
+    assert e(2).symbol == h.Prefix.HECTO
+    assert e(3).symbol == h.Prefix.KILO
+    assert e(6).symbol == h.Prefix.MEGA
+    assert e(9).symbol == h.Prefix.GIGA
+    assert e(12).symbol == h.Prefix.TERA
+    assert e(15).symbol == h.Prefix.PETA
+    assert e(18).symbol == h.Prefix.EXA
+    assert e(21).symbol == h.Prefix.ZETTA
+    assert e(24).symbol == h.Prefix.YOTTA
 
 
 def test_e_mult():
     """Test multiplying by the `e` function results, e.g. `11 * e(-9)"""
-    from hdl21.prefix import e
+    from hdl21.prefix import e, _epsilon_equiv
 
     assert 11 * e(-9) == h.Prefixed(11, h.Prefix.NANO)
+    assert 11 * e(1.5) * e(4.5) == 11 * e(6)
+    assert 11 * e(0.123) * e(0.123) * e(0.123) == 11 * e(0.369)
+    assert 11 * e(1) * e(-1) == 11 * e(0)
+    assert 11 * e(1) * e(-2) * e(3) == 11 * e(2)
+    assert 1 * e(0.123) * e(-0.123) == 1 * e(0)
+    assert 1 * e(-0.5) * e(1) == 1 * e(0.5)
 
+    # Good enough tests
+    assert _epsilon_equiv(1 * e(-3) * e(3.3), 1 * e(0.3), 10)
+    assert _epsilon_equiv(1 * e(-0.75) * e(0.5), 1 * e (-0.25), 25)
+    assert _epsilon_equiv(1 * e(-0.123) * e(0.003) * e(0.1), 1 * e(-0.02), 25)
 
-def test_prefix_scaling():
-    """Test cases of `Prefixed` multiplication which do not land on other `Prefix`es, and require scaling"""
-    from hdl21.prefix import e
+def test_e_pow():
+    """Test raising Prefixed numbers to powers"""
+    from hdl21.prefix import e, _epsilon_equiv
 
-    # Explicit scaling
-    assert (11.11 * e(2)).scale(e(0)) == 1111 * e(0)
-    assert (1.11 * e(-1)).scale(e(-3)) == 111 * e(-3)
-    assert (111 * e(0)).scale(e(3)) == 0.111 * e(3)
+    assert (1 * e(1)) ** 2 == 1 * e(2)
+    assert (2 * e(-2)) ** 2 == 4 * e(-4)
 
-    # Inline Scaling
-    assert 11.11 * e(2) * e(0) == 1111 * e(0)
-    assert 1.11 * e(-2) * e(-3) == 11.1 * e(-6)
-    assert 111 * e(3) * e(3) == 0.111 * e(9)
+    # Good enough tests
+    assert _epsilon_equiv((3 * e(4)) ** 0.25,Decimal(3**0.25)*e(1),15)
 
-    # Automatic Scaling
-    assert (1000 * e(0)).scale() == 1 * e(3)
-    assert (0.001 * e(0)).scale() == 1 * e(-3)
-    assert (1000 * e(3)).scale() == 1 * e(6)
+def test_e_div():
+    """Test dividing Prefixed numbers by numbers"""
+    from hdl21.prefix import e,_epsilon_equiv
+
+    assert e(3)/e(2) == e(1)
+    assert (1*e(3))/(1*e(2)) == 1 * e(1)
+
+    # Test scalar division
+    assert (1*e(2))/2  == 0.5 * e(2) == 5 * e(1)
+
+    # Good enough tests
+    assert _epsilon_equiv((-1*e(-2))/(-1*e(-2.3)), 1 * e(0.3), 10)
+    assert _epsilon_equiv((2*e(2.9))/(4*e(0.4)),0.5*e(2.5),10)
+
 
 def test_prefix_comparison():
     """Test cases of `Prefixed` comparison operators"""
@@ -191,11 +200,6 @@ def test_prefix_comparison():
     assert 1 * e(3) <= 1 * e(3)
     assert 1 * e(-6) <= 1 * e(-3)
     assert 1 * e(-6) <= 1 * e(-6)
-
-    # Equal to
-    assert 1 * e(-3) == 0.001 * e(0)
-    assert 1 * e(0) == 1 * e(0)
-    assert 1 * e(3) == 1000 * e(0)
 
     # Not Equal to
     assert 1 * e(0) != 2 * e(0)

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -66,6 +66,7 @@ def test_prefix_shortname():
     assert h.prefix.Z == h.Prefix.ZETTA
     assert h.prefix.Y == h.Prefix.YOTTA
 
+
 def test_prefix_from_exp():
     """Test creating `Prefix` from an integer exponent."""
 
@@ -91,6 +92,7 @@ def test_prefix_from_exp():
     assert h.Prefix.from_exp(21) == h.Prefix.ZETTA
     assert h.Prefix.from_exp(24) == h.Prefix.YOTTA
 
+
 def test_prefix_mul():
     """Test `Prefix` multiplication."""
     from hdl21.prefix import µ, M, e
@@ -98,7 +100,7 @@ def test_prefix_mul():
     assert 5 * µ == 5 * h.Prefix.MICRO
     assert 5 * µ == h.Prefixed(5, h.Prefix.MICRO)
     assert µ * M == e(0)
-    
+
 
 def test_prefix_div():
     """Test `Prefix` division"""
@@ -112,9 +114,10 @@ def test_prefix_pow():
     """Test `Prefix` exponentiation"""
     from hdl21.prefix import µ, e
 
-    assert µ ** 2 == e(-12)
-    assert µ ** 0.5 == e(-3)
-    assert µ ** -1 == e(6)
+    assert µ**2 == e(-12)
+    assert µ**0.5 == e(-3)
+    assert µ**-1 == e(6)
+
 
 def test_e():
     """Test the `e` shorthand notation for exponential creation"""
@@ -156,8 +159,9 @@ def test_e_mult():
 
     # Good enough tests
     assert _epsilon_equiv(1 * e(-3) * e(3.3), 1 * e(0.3), 10)
-    assert _epsilon_equiv(1 * e(-0.75) * e(0.5), 1 * e (-0.25), 25)
+    assert _epsilon_equiv(1 * e(-0.75) * e(0.5), 1 * e(-0.25), 25)
     assert _epsilon_equiv(1 * e(-0.123) * e(0.003) * e(0.1), 1 * e(-0.02), 25)
+
 
 def test_e_pow():
     """Test raising Prefixed numbers to powers"""
@@ -167,30 +171,38 @@ def test_e_pow():
     assert (2 * e(-2)) ** 2 == 4 * e(-4)
 
     # Good enough tests
-    assert _epsilon_equiv((3 * e(4)) ** 0.25,Decimal(3**0.25)*e(1),15)
+    assert _epsilon_equiv((3 * e(4)) ** 0.25, Decimal(3**0.25) * e(1), 15)
+
 
 def test_e_div():
     """Test dividing Prefixed numbers by numbers"""
-    from hdl21.prefix import e,_epsilon_equiv
+    from hdl21.prefix import e, _epsilon_equiv
 
-    assert e(3)/e(2) == e(1)
-    assert (1*e(3))/(1*e(2)) == 1 * e(1)
+    assert e(3) / e(2) == e(1)
+    assert (1 * e(3)) / (1 * e(2)) == 1 * e(1)
 
     # Test scalar division
-    assert (1*e(2))/2  == 0.5 * e(2) == 5 * e(1)
+    assert (1 * e(2)) / 2 == 0.5 * e(2) == 5 * e(1)
 
     # Good enough tests
-    assert _epsilon_equiv((-1*e(-2))/(-1*e(-2.3)), 1 * e(0.3), 10)
-    assert _epsilon_equiv((2*e(2.9))/(4*e(0.4)),0.5*e(2.5),10)
+    assert _epsilon_equiv((-1 * e(-2)) / (-1 * e(-2.3)), 1 * e(0.3), 10)
+    assert _epsilon_equiv((2 * e(2.9)) / (4 * e(0.4)), 0.5 * e(2.5), 10)
+
 
 def test_prefix_scaling():
     """Test cases of `Prefixed` multiplication which do not land on other `Prefix`es, and require scaling"""
     from hdl21.prefix import e, _epsilon_equiv
 
     # Explicit scaling
-    assert _epsilon_equiv((Decimal(11.11) * e(2)).scale(e(0).symbol),Decimal(1111) * e(0), 12)
-    assert _epsilon_equiv((Decimal(1.11) * e(-1)).scale(e(-3).symbol), Decimal(111) * e(-3), 12)
-    assert _epsilon_equiv((Decimal(111) * e(0)).scale(e(3).symbol), Decimal(0.111) * e(3), 12)
+    assert _epsilon_equiv(
+        (Decimal(11.11) * e(2)).scale(e(0).symbol), Decimal(1111) * e(0), 12
+    )
+    assert _epsilon_equiv(
+        (Decimal(1.11) * e(-1)).scale(e(-3).symbol), Decimal(111) * e(-3), 12
+    )
+    assert _epsilon_equiv(
+        (Decimal(111) * e(0)).scale(e(3).symbol), Decimal(0.111) * e(3), 12
+    )
 
     # Inline Scaling
     assert _epsilon_equiv(Decimal(11.11) * e(2) * e(0), Decimal(1111) * e(0), 12)
@@ -198,9 +210,10 @@ def test_prefix_scaling():
     assert _epsilon_equiv(111 * e(3) * e(3), 0.111 * e(9), 12)
 
     # Automatic Scaling
-    assert _epsilon_equiv((1000 * e(0)).scale(), 1 * e(3),12)
-    assert _epsilon_equiv((0.001 * e(0)).scale(), 1 * e(-3),12)
-    assert _epsilon_equiv((1000 * e(3)).scale(), 1 * e(6),12)
+    assert _epsilon_equiv((1000 * e(0)).scale(), 1 * e(3), 12)
+    assert _epsilon_equiv((0.001 * e(0)).scale(), 1 * e(-3), 12)
+    assert _epsilon_equiv((1000 * e(3)).scale(), 1 * e(6), 12)
+
 
 def test_prefix_comparison():
     """Test cases of `Prefixed` comparison operators"""
@@ -236,7 +249,7 @@ def test_prefix_comparison():
     assert 1 * e(3) >= 1 * e(3)
     assert 1 * e(-3) >= 1 * e(-6)
     assert 1 * e(-6) >= 1 * e(-6)
-   
+
 
 def test_prefix_conversion():
     """Test types that can be converted to `Prefixed`'s internal `Decimal`."""

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -183,6 +183,24 @@ def test_e_div():
     assert _epsilon_equiv((-1*e(-2))/(-1*e(-2.3)), 1 * e(0.3), 10)
     assert _epsilon_equiv((2*e(2.9))/(4*e(0.4)),0.5*e(2.5),10)
 
+def test_prefix_scaling():
+    """Test cases of `Prefixed` multiplication which do not land on other `Prefix`es, and require scaling"""
+    from hdl21.prefix import e, _epsilon_equiv
+
+    # Explicit scaling
+    assert _epsilon_equiv((Decimal(11.11) * e(2)).scale(e(0).symbol),Decimal(1111) * e(0), 12)
+    assert _epsilon_equiv((Decimal(1.11) * e(-1)).scale(e(-3).symbol), Decimal(111) * e(-3), 12)
+    assert _epsilon_equiv((Decimal(111) * e(0)).scale(e(3).symbol), Decimal(0.111) * e(3), 12)
+
+    # Inline Scaling
+    assert _epsilon_equiv(Decimal(11.11) * e(2) * e(0), Decimal(1111) * e(0), 12)
+    assert _epsilon_equiv(1.11 * e(-2) * e(-3), 11.1 * e(-6), 12)
+    assert _epsilon_equiv(111 * e(3) * e(3), 0.111 * e(9), 12)
+
+    # Automatic Scaling
+    assert _epsilon_equiv((1000 * e(0)).scale(), 1 * e(3),12)
+    assert _epsilon_equiv((0.001 * e(0)).scale(), 1 * e(-3),12)
+    assert _epsilon_equiv((1000 * e(3)).scale(), 1 * e(6),12)
 
 def test_prefix_comparison():
     """Test cases of `Prefixed` comparison operators"""

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -2,6 +2,7 @@ import hdl21 as h
 from decimal import Decimal, getcontext
 import pytest as pt
 
+
 def test_decimal():
     """This isnt a test of Hdl21 so much as a demo and reminder of how
     the standard library's `Decimal` works, particularly in conjunction with
@@ -247,18 +248,18 @@ def test_prefix_scaling():
     from hdl21.prefix import e
 
     # Explicit scaling
-    assert (Decimal('11.11') * e(2)).scale(e(0).symbol) == Decimal(1111) * e(0)
-    assert (Decimal('1.11') * e(-1)).scale(e(-3).symbol) == Decimal(111) * e(-3)
-    assert (Decimal(111) * e(0)).scale(e(3).symbol) == Decimal('0.111') * e(3)
+    assert (Decimal("11.11") * e(2)).scale(e(0).symbol) == Decimal(1111) * e(0)
+    assert (Decimal("1.11") * e(-1)).scale(e(-3).symbol) == Decimal(111) * e(-3)
+    assert (Decimal(111) * e(0)).scale(e(3).symbol) == Decimal("0.111") * e(3)
 
     # Inline Scaling
-    assert Decimal('11.11') * e(2) * e(0) == Decimal(1111) * e(0)
-    assert Decimal('1.11') * e(-2) * e(-3) == Decimal('11.1') * e(-6)
-    assert 111 * e(3) * e(3) == Decimal('0.111') * e(9)
+    assert Decimal("11.11") * e(2) * e(0) == Decimal(1111) * e(0)
+    assert Decimal("1.11") * e(-2) * e(-3) == Decimal("11.1") * e(-6)
+    assert 111 * e(3) * e(3) == Decimal("0.111") * e(9)
 
     # Automatic Scaling
     assert (1000 * e(0)).scale(), 1 * e(3)
-    assert (Decimal('0.001') * e(0)).scale(), 1 * e(-3)
+    assert (Decimal("0.001") * e(0)).scale(), 1 * e(-3)
     assert (1000 * e(3)).scale(), 1 * e(6)
 
 
@@ -300,13 +301,16 @@ def test_prefix_comparison():
     # Equal to with special emphasis on precision error
     assert 0.123 * e(3) == 123 * e(0)
     assert 0.456 * e(-2) == 4.56 * e(-3)
-    assert (2 * e(1/3)) ** 2 == 4 * e(2/3)
+    assert (2 * e(1 / 3)) ** 2 == 4 * e(2 / 3)
+
 
 def test_prefix_conversion():
     """Test types that can be converted to `Prefixed`'s internal `Decimal`."""
     from hdl21.prefix import e, y
 
-    assert h.Prefixed(number="11.11", prefix=y) == h.Prefixed(Decimal("11.11"), prefix=y)
+    assert h.Prefixed(number="11.11", prefix=y) == h.Prefixed(
+        Decimal("11.11"), prefix=y
+    )
     assert h.Prefixed(number=11.11, prefix=y) == h.Prefixed(Decimal("11.11"), prefix=y)
     assert h.Prefixed(number=11, prefix=y) == h.Prefixed(Decimal(11), prefix=y)
 

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -167,13 +167,13 @@ def test_prefix_scaling():
 
     # Inline Scaling
     assert 11.11 * e(2) * e(0) == 1111 * e(0)
-    assert 1.11 * e(-1) * e(-3) == 111 * e(-4)
-    assert 111 * e(0) * e(3) == 0.111 * e(3)
+    assert 1.11 * e(-2) * e(-3) == 11.1 * e(-6)
+    assert 111 * e(3) * e(3) == 0.111 * e(9)
 
     # Automatic Scaling
     assert (1000 * e(0)).scale() == 1 * e(3)
     assert (0.001 * e(0)).scale() == 1 * e(-3)
-    assert (1000 * e(3)).scale == 1 * e(6)
+    assert (1000 * e(3)).scale() == 1 * e(6)
 
 def test_prefix_comparison():
     """Test cases of `Prefixed` comparison operators"""

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -1,7 +1,6 @@
 import hdl21 as h
-from decimal import Decimal
+from decimal import Decimal, getcontext
 import pytest as pt
-
 
 def test_decimal():
     """This isnt a test of Hdl21 so much as a demo and reminder of how
@@ -147,30 +146,30 @@ def test_prefixed_pow():
 
 def test_prefixed_addition():
     """Test `Prefixed Addition"""
-    from hdl21.prefix import e, _epsilon_equiv
+    from hdl21.prefix import e
 
     assert (1 * e(0)) + (1 * e(0)) == 2 * e(0)
     assert (1 * e(0)) + (1 * e(-2)) == 101 * e(-2)
     assert (1 * e(2)) + (1 * e(0)) == 101 * e(0)
 
-    # Good enough tests
-    assert _epsilon_equiv((1 * e(0)) + (1 * e(0)), 0.2 * e(1), 10)
-    assert _epsilon_equiv((1 * e(0)) + (1 * e(-2)), 1.01 * e(0), 10)
-    assert _epsilon_equiv((1 * e(2)) + (1 * e(0)), 1.01 * e(2), 10)
+    # Precision-error tests
+    assert (1 * e(0)) + (1 * e(0)) == 0.2 * e(1)
+    assert (1 * e(0)) + (1 * e(-2)) == 1.01 * e(0)
+    assert (1 * e(2)) + (1 * e(0)) == 1.01 * e(2)
 
 
 def test_prefixed_subtraction():
     """Test `Prefixed` Subtraction"""
-    from hdl21.prefix import e, _epsilon_equiv
+    from hdl21.prefix import e
 
     assert (1 * e(0)) - (1 * e(0)) == 0 * e(0)
     assert (1 * e(0)) - (1 * e(-2)) == 99 * e(-2)
     assert (1 * e(2)) - (1 * e(0)) == 99 * e(0)
 
-    # Good enough tests
-    assert _epsilon_equiv((1 * e(0)) - (1 * e(0)), 0.0 * e(1), 10)
-    assert _epsilon_equiv((1 * e(0)) - (1 * e(-2)), 0.99 * e(0), 10)
-    assert _epsilon_equiv((1 * e(2)) - (1 * e(0)), 0.99 * e(2), 10)
+    # Precision-error tests
+    assert (1 * e(0)) - (1 * e(0)) == 0.0 * e(1)
+    assert (1 * e(0)) - (1 * e(-2)) == 0.99 * e(0)
+    assert (1 * e(2)) - (1 * e(0)) == 0.99 * e(2)
 
 
 def test_e():
@@ -201,7 +200,7 @@ def test_e():
 
 def test_e_mult():
     """Test multiplying by the `e` function results, e.g. `11 * e(-9)"""
-    from hdl21.prefix import e, _epsilon_equiv
+    from hdl21.prefix import e
 
     assert 11 * e(-9) == h.Prefixed(11, h.Prefix.NANO)
     assert 11 * e(1.5) * e(4.5) == 11 * e(6)
@@ -209,28 +208,28 @@ def test_e_mult():
     assert 11 * e(1) * e(-2) * e(3) == 11 * e(2)
     assert 1 * e(-0.5) * e(1) == 1 * e(0.5)
 
-    # Good enough tests
-    assert _epsilon_equiv(1 * e(-3) * e(3.3), 1 * e(0.3), 10)
-    assert _epsilon_equiv(1 * e(-0.75) * e(0.5), 1 * e(-0.25), 10)
-    assert _epsilon_equiv(1 * e(-0.123) * e(0.003) * e(0.1), 1 * e(-0.02), 10)
-    assert _epsilon_equiv(11 * e(0.123) * e(0.123) * e(0.123), 11 * e(0.369), 10)
-    assert _epsilon_equiv(1 * e(0.123) * e(-0.123), 1 * e(0), 10)
+    # Precision-error tests
+    assert 1 * e(-3) * e(3.3) == 1 * e(0.3)
+    assert 1 * e(-0.75) * e(0.5) == 1 * e(-0.25)
+    assert 1 * e(-0.123) * e(0.003) * e(0.1) == 1 * e(-0.02)
+    assert 11 * e(0.123) * e(0.123) * e(0.123) == 11 * e(0.369)
+    assert 1 * e(0.123) * e(-0.123) == 1 * e(0)
 
 
 def test_e_pow():
     """Test raising Prefixed numbers to powers"""
-    from hdl21.prefix import e, _epsilon_equiv
+    from hdl21.prefix import e
 
     assert (1 * e(1)) ** 2 == 1 * e(2)
     assert (2 * e(-2)) ** 2 == 4 * e(-4)
 
-    # Good enough tests
-    assert _epsilon_equiv((3 * e(4)) ** 0.25, Decimal(3**0.25) * e(1), 15)
+    # Precision-error tests
+    assert (3 * e(4)) ** 0.25, Decimal(3**0.25) * e(1)
 
 
 def test_e_div():
     """Test dividing Prefixed numbers by numbers"""
-    from hdl21.prefix import e, _epsilon_equiv
+    from hdl21.prefix import e
 
     assert e(3) / e(2) == e(1)
     assert (1 * e(3)) / (1 * e(2)) == 1 * e(1)
@@ -238,35 +237,29 @@ def test_e_div():
     # Test scalar division
     assert (1 * e(2)) / 2 == 0.5 * e(2) == 5 * e(1)
 
-    # Good enough tests
-    assert _epsilon_equiv((-1 * e(-2)) / (-1 * e(-2.3)), 1 * e(0.3), 10)
-    assert _epsilon_equiv((2 * e(2.9)) / (4 * e(0.4)), 0.5 * e(2.5), 10)
+    # Precision-error tests
+    assert (-1 * e(-2)) / (-1 * e(-2.3)) == 1 * e(0.3)
+    assert (2 * e(2.9)) / (4 * e(0.4)) == 0.5 * e(2.5)
 
 
 def test_prefix_scaling():
     """Test cases of `Prefixed` multiplication which do not land on other `Prefix`es, and require scaling"""
-    from hdl21.prefix import e, _epsilon_equiv
+    from hdl21.prefix import e
 
     # Explicit scaling
-    assert _epsilon_equiv(
-        (Decimal(11.11) * e(2)).scale(e(0).symbol), Decimal(1111) * e(0), 12
-    )
-    assert _epsilon_equiv(
-        (Decimal(1.11) * e(-1)).scale(e(-3).symbol), Decimal(111) * e(-3), 12
-    )
-    assert _epsilon_equiv(
-        (Decimal(111) * e(0)).scale(e(3).symbol), Decimal(0.111) * e(3), 12
-    )
+    assert (Decimal('11.11') * e(2)).scale(e(0).symbol) == Decimal(1111) * e(0)
+    assert (Decimal('1.11') * e(-1)).scale(e(-3).symbol) == Decimal(111) * e(-3)
+    assert (Decimal(111) * e(0)).scale(e(3).symbol) == Decimal('0.111') * e(3)
 
     # Inline Scaling
-    assert _epsilon_equiv(Decimal(11.11) * e(2) * e(0), Decimal(1111) * e(0), 12)
-    assert _epsilon_equiv(1.11 * e(-2) * e(-3), 11.1 * e(-6), 12)
-    assert _epsilon_equiv(111 * e(3) * e(3), 0.111 * e(9), 12)
+    assert Decimal('11.11') * e(2) * e(0) == Decimal(1111) * e(0)
+    assert Decimal('1.11') * e(-2) * e(-3) == Decimal('11.1') * e(-6)
+    assert 111 * e(3) * e(3) == Decimal('0.111') * e(9)
 
     # Automatic Scaling
-    assert _epsilon_equiv((1000 * e(0)).scale(), 1 * e(3), 12)
-    assert _epsilon_equiv((0.001 * e(0)).scale(), 1 * e(-3), 12)
-    assert _epsilon_equiv((1000 * e(3)).scale(), 1 * e(6), 12)
+    assert (1000 * e(0)).scale(), 1 * e(3)
+    assert (Decimal('0.001') * e(0)).scale(), 1 * e(-3)
+    assert (1000 * e(3)).scale(), 1 * e(6)
 
 
 def test_prefix_comparison():
@@ -304,20 +297,18 @@ def test_prefix_comparison():
     assert 1 * e(-3) >= 1 * e(-6)
     assert 1 * e(-6) >= 1 * e(-6)
 
+    # Equal to with special emphasis on precision error
+    assert 0.123 * e(3) == 123 * e(0)
+    assert 0.456 * e(-2) == 4.56 * e(-3)
+    assert (2 * e(1/3)) ** 2 == 4 * e(2/3)
 
 def test_prefix_conversion():
     """Test types that can be converted to `Prefixed`'s internal `Decimal`."""
-    from hdl21.prefix import e, y, _epsilon_equiv
+    from hdl21.prefix import e, y
 
-    assert _epsilon_equiv(
-        h.Prefixed(number="11.11", prefix=y), h.Prefixed(Decimal(11.11), y), 10
-    )
-    assert _epsilon_equiv(
-        h.Prefixed(number=11.11, prefix=y), h.Prefixed(Decimal(11.11), prefix=y), 10
-    )
-    assert _epsilon_equiv(
-        h.Prefixed(number=11, prefix=y), h.Prefixed(Decimal(11), y), 10
-    )
+    assert h.Prefixed(number="11.11", prefix=y) == h.Prefixed(Decimal("11.11"), prefix=y)
+    assert h.Prefixed(number=11.11, prefix=y) == h.Prefixed(Decimal("11.11"), prefix=y)
+    assert h.Prefixed(number=11, prefix=y) == h.Prefixed(Decimal(11), prefix=y)
 
     assert type(float(1 * e(1))) == float
     assert float(1 * e(1)) == 10.0
@@ -329,7 +320,7 @@ def test_unit_prefix():
     """Test the UNIT prefix"""
     assert h.Prefixed(11) == h.Prefixed(11, h.Prefix.UNIT)
     assert h.Prefixed("11") == h.Prefixed(11)
-    assert h.Prefixed("11") == h.Prefixed(11.0)
+    assert h.Prefixed(11.0) == h.Prefixed(11.0)
 
 
 def test_not_implemented_prefix():


### PR DESCRIPTION
External PR to specifically resolve Issue #62.

### Prefix

- Fixed `Prefix.from_exp()` FIXME
- Added `__mul__` for Prefix * Prefix
- Added Prefix * Prefix `__rmul__`
- Added `__truediv__` for Prefix / Prefix
- Added `__pow__` for Prefix ** int/float/Decimal

### Prefixed

- Added `__int__` method 
- Added `__mul__` method with other : Prefixed
- Added `__rmul__` method with other : Prefixed
- Added `__truediv__` method with other : Prefixed
- Added `__pow__` for other : int/float/Decimal
- Replaced `scaleto` with `scale` incl. autoscaling method when no arguments are given
- Implemented all comparison operators as requested
- Added `_scale_to_smaller` method to do routine operation in comparison quickly
- Added yocto, zepto, atto, exa, zetta, yotta single-character identifiers

### Tests

- Added to `test_prefix_shortname` to include new identifiers
- Added to `test_prefix_from_exp` to include autoscaling checks
- Added to `test_prefix_mul` Prefix * Prefix test
- Added New Test `test_prefix_div`
- Added New Test `test_prefix_pow`
- Modified `test_prefix_scaling` to new scale function with autoscaling paradigm
- Added New Test `test_prefix_comparison` includes all cases of comparisons

### Possible TO-DO

`.from_exp` is changed to move the provided `n` in `e(n)` to the closest known SI prefix (eg. 2.7->3, -4.4 -> -3 etc.). A more natural system would be to encode a "true prefix" that allows multiplication by `e(n)` where `n` isn't an SI prefix to behave like the normal exponentiation key on a calculator, ie.
```
eg. 11.1 * e(2.7) A == 5.5 KA etc. etc.
```