### PR TITLE
feat: add type hints support for class types

### DIFF
--- a/hdl21/attrmagic.py
+++ b/hdl21/attrmagic.py
@@ -19,8 +19,13 @@ The scheme adopted here is what we've empirically observed to be the most reliab
 The methods here primarily serve as a central reminder of and reusable source for this scheme. 
 """
 
+from typing import TypeVar, Type
 
-def init(cls: type) -> type:
+
+T = TypeVar("T")
+
+
+def init(cls: Type[T]) -> Type[T]:
     """
     Initialization decorator for "attr magic" types.
 

--- a/hdl21/concatable.py
+++ b/hdl21/concatable.py
@@ -6,9 +6,11 @@ Solely a marker used by `Concat` for validity checking.
 
 # Local imports
 from .connect import is_connectable
+from typing import TypeVar, Type
 
+T = TypeVar("T")
 
-def concatable(cls: type) -> type:
+def concatable(cls: Type[T]) -> Type[T]:
     """Decorator for `Concat`-compatible types."""
     if not is_connectable(cls):
         raise TypeError(f"{cls} is not connectable")

--- a/hdl21/concatable.py
+++ b/hdl21/concatable.py
@@ -10,6 +10,7 @@ from typing import TypeVar, Type
 
 T = TypeVar("T")
 
+
 def concatable(cls: Type[T]) -> Type[T]:
     """Decorator for `Concat`-compatible types."""
     if not is_connectable(cls):

--- a/hdl21/connect.py
+++ b/hdl21/connect.py
@@ -5,10 +5,12 @@ Applied to types that are "used as connections", e.g. Signal.
 """
 
 # Std-Lib Imports
-from typing import Any, Union
+from typing import Any, Union, TypeVar, Type
+
+T = TypeVar("T")
 
 
-def connectable(cls: type) -> type:
+def connectable(cls: Type[T]) -> Type[T]:
     """Decorator for connectable types"""
     cls.__connectable__ = True
     return cls

--- a/hdl21/datatype.py
+++ b/hdl21/datatype.py
@@ -28,12 +28,13 @@ Notes:
 """
 
 from pydantic.dataclasses import dataclass
+from typing import TypeVar, Type
 
 # The list of defined datatypes
 datatypes = []
 
 
-def datatype(cls: type) -> type:
+def datatype(cls: Type[T]) -> Type[T]:
     """Register a class as a datatype."""
 
     # Convert `cls` to a `pydantic.dataclasses.dataclass`,

--- a/hdl21/datatype.py
+++ b/hdl21/datatype.py
@@ -33,6 +33,8 @@ from typing import TypeVar, Type
 # The list of defined datatypes
 datatypes = []
 
+T = TypeVar("T")
+
 
 def datatype(cls: Type[T]) -> Type[T]:
     """Register a class as a datatype."""

--- a/hdl21/elab/elab.py
+++ b/hdl21/elab/elab.py
@@ -17,6 +17,7 @@ from .elabpass import ElabPass
 
 ElaboratableType = TypeVar("ElaboratableType", bound=Elaboratable)
 
+
 def elaborate(
     top: ElaboratableType,
     *,

--- a/hdl21/elab/elab.py
+++ b/hdl21/elab/elab.py
@@ -7,7 +7,7 @@ performing one or more transformation-passes.
 """
 
 # Std-Lib Imports
-from typing import List, Optional
+from typing import List, Optional, TypeVar
 
 # Local imports
 from .elaboratable import Elaboratable, Elaboratables, is_elaboratable
@@ -15,12 +15,14 @@ from .context import Context
 from .elabpass import ElabPass
 
 
+ElaboratableType = TypeVar("ElaboratableType", bound=Elaboratable)
+
 def elaborate(
-    top: Elaboratables,
+    top: ElaboratableType,
     *,
     ctx: Optional[Context] = None,
     passes: Optional[List[ElabPass]] = None,
-) -> Elaboratables:
+) -> ElaboratableType:
     """
     # Hdl21 Elaboration
 

--- a/hdl21/instance.py
+++ b/hdl21/instance.py
@@ -16,6 +16,7 @@ from .connect import Connectable, is_connectable
 
 T = TypeVar("T")
 
+
 @init
 class _Instance:
     """Shared base class for Instance-like types (Instance, InstanceArray)"""

--- a/hdl21/instance.py
+++ b/hdl21/instance.py
@@ -5,7 +5,7 @@ Create instances of Modules, Generators, and Primitives in a hierarchy
 """
 
 # Std-Lib Imports
-from typing import Optional, Any, Dict
+from typing import Optional, Any, Dict, Type, TypeVar
 from dataclasses import dataclass, field
 from textwrap import dedent
 
@@ -14,6 +14,7 @@ from .source_info import source_info, SourceInfo
 from .attrmagic import init
 from .connect import Connectable, is_connectable
 
+T = TypeVar("T")
 
 @init
 class _Instance:
@@ -343,7 +344,7 @@ Instantiation Decorator
 """
 
 
-def calls_instantiate(cls: type) -> type:
+def calls_instantiate(cls: Type[T]) -> Type[T]:
     """# Calls Instantiate
     Decorator which adds 'calls produce `hdl21.Instance`s' functionality.
     Added to `Module`, `GeneratorCall`, and everything else that is `Instantiable`."""

--- a/hdl21/qualname.py
+++ b/hdl21/qualname.py
@@ -32,7 +32,9 @@ def qualname(mod: Union["Module", "ExternalModule"]) -> Optional[str]:
     # Defined the old fashioned way. Use the Python module name.
     return mod._source_info.pymodule.__name__ + "." + mod.name
 
+
 T = TypeVar("T")
+
 
 def qualname_magic_methods(cls: Type[T]) -> Type[T]:
     """Decorator to add the 'use qualname for equality, hashing, and pickling'

--- a/hdl21/qualname.py
+++ b/hdl21/qualname.py
@@ -7,7 +7,7 @@ and many of their import/ export languages (e.g. Verilog, netlists) do not.
 """
 
 
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, TypeVar, Type
 
 
 def qualname(mod: Union["Module", "ExternalModule"]) -> Optional[str]:
@@ -32,8 +32,9 @@ def qualname(mod: Union["Module", "ExternalModule"]) -> Optional[str]:
     # Defined the old fashioned way. Use the Python module name.
     return mod._source_info.pymodule.__name__ + "." + mod.name
 
+T = TypeVar("T")
 
-def qualname_magic_methods(cls) -> type:
+def qualname_magic_methods(cls: Type[T]) -> Type[T]:
     """Decorator to add the 'use qualname for equality, hashing, and pickling'
     magic methods to a class."""
 

--- a/hdl21/sliceable.py
+++ b/hdl21/sliceable.py
@@ -2,12 +2,14 @@
 # Slice-Enabling Decorator
 """
 
-from typing import Union
+from typing import Union, TypeVar, Type
 
 from .connect import is_connectable
 
+T = TypeVar("T")
 
-def sliceable(cls: type) -> type:
+
+def sliceable(cls: Type[T]) -> Type[T]:
     """Decorator to add the 'square-bracket indexing produces `Slice`s' behavior."""
 
     if getattr(cls, "__getitem__", None) is not None:


### PR DESCRIPTION
Better support type hints for linters to work better.

For example, previously linter would complain about this

```python
def elaborate_once(m: h.Module) -> h.Module:
    return m.elaborate(m)
```

Because the return type of `m.elaborate` is a generic `Elaboratable` which might not be a `Module`.
Using type vars here and there reduces problems like this.

There are more cases like this in the repository where type vars should be used, but these are the ones that I personally used. Maybe we should wait until all such cases are covered then do a big PR.