### PR TITLE
Replace asyncio with concurrent.futures, add tests

### DIFF
--- a/hdl21/sim/data.py
+++ b/hdl21/sim/data.py
@@ -410,6 +410,25 @@ def run(
 
     return vsp.sim(inp=to_proto(inp), opts=opts)
 
+def run_async(
+    inp: OneOrMore[Sim], opts: Optional[vsp.SimOptions] = None
+) -> OneOrMore[vsp.SimResultUnion]:
+    """Invoke simulation via `vlsirtools.spice`."""
+    from .to_proto import to_proto
+
+    # FIXME: go through with deprecation
+    warn(
+        PendingDeprecationWarning(
+            dedent(
+                """\
+        Async `hdl21.Sim` invocation will be deprecated and `run_async` will be removed with the next major version.
+        Use `run` instead, which now parallelizes across simulation processes internally.
+    """
+            )
+        )
+    )
+
+    return vsp.sim(inp=to_proto(inp), opts=opts)
 
 def _add_attr_func(name: str, cls: type):
     # Create the internal "construct + add" closure

--- a/hdl21/sim/data.py
+++ b/hdl21/sim/data.py
@@ -410,6 +410,7 @@ def run(
 
     return vsp.sim(inp=to_proto(inp), opts=opts)
 
+
 def run_async(
     inp: OneOrMore[Sim], opts: Optional[vsp.SimOptions] = None
 ) -> OneOrMore[vsp.SimResultUnion]:
@@ -429,6 +430,7 @@ def run_async(
     )
 
     return vsp.sim(inp=to_proto(inp), opts=opts)
+
 
 def _add_attr_func(name: str, cls: type):
     # Create the internal "construct + add" closure

--- a/hdl21/sim/data.py
+++ b/hdl21/sim/data.py
@@ -391,12 +391,6 @@ class Sim:
         """Invoke simulation via `vlsirtools.spice`."""
         return run(self, opts=opts)
 
-    async def run_async(
-        self, opts: Optional[vsp.SimOptions] = None
-    ) -> Awaitable[vsp.SimResultUnion]:
-        """Invoke simulation via `vlsirtools.spice`."""
-        return await run_async(self, opts=opts)
-
     @property
     def Tb(self) -> "Module":
         """Get our testbench Module, with a class-style accessor name."""
@@ -415,27 +409,6 @@ def run(
     # inp.Tb.props.set("simulator", opts.simulator.value)
 
     return vsp.sim(inp=to_proto(inp), opts=opts)
-
-
-async def run_async(
-    inp: OneOrMore[Sim], opts: Optional[vsp.SimOptions] = None
-) -> Awaitable[OneOrMore[vsp.SimResultUnion]]:
-    """Invoke simulation via `vlsirtools.spice`."""
-    from .to_proto import to_proto
-
-    # FIXME: go through with deprecation
-    warn(
-        PendingDeprecationWarning(
-            dedent(
-                """\
-        Async `hdl21.Sim` invocation will be deprecated and `run_async` will be removed with the next major version.
-        Use `run` instead, which now parallelizes across simulation processes internally.
-    """
-            )
-        )
-    )
-
-    return await vsp.sim_async(inp=to_proto(inp), opts=opts)
 
 
 def _add_attr_func(name: str, cls: type):
@@ -517,7 +490,7 @@ def sim(cls: type) -> Sim:
     if cls.__bases__ != (object,):
         raise RuntimeError(f"Invalid @hdl21.sim inheriting from {cls.__bases__}")
 
-    protected_names = ["attrs", "add", "run", "run_async", "namespace"]
+    protected_names = ["attrs", "add", "run", "namespace"]
 
     # Initialize the content of the eventual `Sim`.
     # Note we largely can't create it now because the `tb` field is required at construction time.

--- a/hdl21/sim/tests/test_sim.py
+++ b/hdl21/sim/tests/test_sim.py
@@ -2,7 +2,7 @@
 # `hdl21.sim` Unit Tests
 """
 
-import asyncio, pytest
+import pytest
 
 import hdl21 as h
 from hdl21.sim import *
@@ -265,7 +265,7 @@ def test_delay1():
     # FIXME! some real checks plz
 
 
-def empty_tb() -> h.Module:
+def empty_tb(num=0) -> h.Module:
     from hdl21.prefix import K
     from hdl21.primitives import R
 
@@ -281,7 +281,7 @@ def empty_tb() -> h.Module:
         s = h.Signal()
         r = ri(p=s, n=VSS)
 
-    EmptyTb.name = "EmptyTb"
+    EmptyTb.name = f"EmptyTb{num}"
     return EmptyTb
 
 
@@ -314,18 +314,34 @@ def test_empty_sim2():
     assert isinstance(r, sd.SimResult)
     assert not len(r.an)  # No analysis inputs, no analysis results
 
+def test_multi_sim():
+    """Test multiple Sims in parallel"""
+    s1 = Sim(tb=empty_tb(1), attrs=[])
+    s2 = Sim(tb=empty_tb(2), attrs=[])
+    s3 = Sim(tb=empty_tb(3), attrs=[])
+    s4 = Sim(tb=empty_tb(4), attrs=[])
 
-@pytest.mark.skipif(
-    vlsirtools.spice.default() is None,
-    reason="No simulator available",
-)
-def test_sim_async_caller():
-    """# Test invoking simulation from an async caller"""
+    r = sim(to_proto([s1, s2, s3, s4]), SimOptions(fmt=ResultFormat.VLSIR_PROTO))
 
-    async def caller():
-        """# The asynchronous caller of `sim_async`"""
-        s = Sim(tb=empty_tb(), attrs=[])
-        return await s.run_async(SimOptions(fmt=ResultFormat.SIM_DATA))
+    for a in r:
+        assert isinstance(a, vsp.SimResult)
+        assert not len(a.an)
 
-    result = asyncio.run(caller())
-    assert isinstance(result, sd.SimResult)
+def really_empty_tb() -> h.Module:
+
+    @h.module
+    class ReallyEmptyTb:
+        """An Empty TestBench, this time REALLY empty.
+        For inducing an error in a multi-sim below."""
+
+    return ReallyEmptyTb
+
+def test_multi_sim_error():
+    """Test multiple sims fail to avoid erdewit/nest_asyncio#57"""
+    with pytest.raises(Exception):
+        s1 = Sim(tb=empty_tb(1), attrs=[])
+        s2 = Sim(tb=really_empty_tb(), attrs=[])
+        s3 = Sim(tb=empty_tb(3), attrs=[])
+        s4 = Sim(tb=empty_tb(4), attrs=[])
+
+        r = sim(to_proto([s1, s2, s3, s4]), SimOptions(fmt=ResultFormat.VLSIR_PROTO))

--- a/hdl21/sim/tests/test_sim.py
+++ b/hdl21/sim/tests/test_sim.py
@@ -339,7 +339,7 @@ def really_empty_tb() -> h.Module:
 
 
 def test_multi_sim_error():
-    """Test multiple sims fail to avoid erdewit/nest_asyncio#57"""
+    """Test that a failure in multiple concurrent sims fails, unlike in erdewit/nest_asyncio#57"""
     with pytest.raises(Exception):
         s1 = Sim(tb=empty_tb(1), attrs=[])
         s2 = Sim(tb=really_empty_tb(), attrs=[])

--- a/hdl21/sim/tests/test_sim.py
+++ b/hdl21/sim/tests/test_sim.py
@@ -314,6 +314,7 @@ def test_empty_sim2():
     assert isinstance(r, sd.SimResult)
     assert not len(r.an)  # No analysis inputs, no analysis results
 
+
 def test_multi_sim():
     """Test multiple Sims in parallel"""
     s1 = Sim(tb=empty_tb(1), attrs=[])
@@ -327,14 +328,15 @@ def test_multi_sim():
         assert isinstance(a, vsp.SimResult)
         assert not len(a.an)
 
-def really_empty_tb() -> h.Module:
 
+def really_empty_tb() -> h.Module:
     @h.module
     class ReallyEmptyTb:
         """An Empty TestBench, this time REALLY empty.
         For inducing an error in a multi-sim below."""
 
     return ReallyEmptyTb
+
 
 def test_multi_sim_error():
     """Test multiple sims fail to avoid erdewit/nest_asyncio#57"""


### PR DESCRIPTION
Resolves:

- https://github.com/dan-fritchman/Hdl21/issues/122

Twinned with:

- https://github.com/Vlsir/Vlsir/pull/68

Major changes:

- Scrub asyncio
- Deprecate `sim.run_async`
- Add test to test multi-input simulation running in parallel
- Add test to demonstrate solution to: https://github.com/erdewit/nest_asyncio/issues/57