### PR TITLE
FEAT: Convert numeric to prefixed value function

### DIFF
--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -17,6 +17,7 @@ with the multiplication operator, to construct values such as `11 * e(-21)`.
 
 from enum import Enum
 from decimal import Decimal
+from math import log10, floor
 from typing import Optional, Any, Union, Tuple
 from pydantic import BaseModel, ValidationError, Field
 from pydantic.dataclasses import dataclass
@@ -456,6 +457,53 @@ def e(exp: Any) -> Exponent:
         return Exponent(out_symbol, out_residual)
 
     return NotImplemented
+
+def convert_numeric_to_prefix(
+    value: float,
+):
+    """
+    This function converts a numeric value to a number under a SPICE unit closest to the base prefix. This allows us to connect a particular number real output, into a term that can be used in a SPICE netlist.
+    """
+    prefixes = [
+        (Prefix.YOCTO, y),
+        (Prefix.ZEPTO, z),
+        (Prefix.ATTO, a),
+        (Prefix.FEMTO, f),
+        (Prefix.PICO, p),
+        (Prefix.NANO, n),
+        (Prefix.MICRO, µ),
+        (Prefix.MICRO, u),
+        (Prefix.MILLI, m),
+        (Prefix.CENTI, c),
+        (Prefix.DECI, d),
+        # (Prefix.UNIT, ''),
+        (Prefix.DECA, D),
+        (Prefix.KILO, K),
+        (Prefix.MEGA, M),
+        (Prefix.GIGA, G),
+        (Prefix.TERA, T),
+        (Prefix.PETA, P),
+        (Prefix.EXA, E),
+        (Prefix.ZETTA, Z),
+        (Prefix.YOTTA, Y),
+    ]
+
+    target_prefix_inclusion_difference = 3
+    base_10 = log10(value)
+    value_target_base = floor(base_10)
+
+    closest_prefix = None
+    min_difference = 2
+    for prefix, _ in prefixes:
+        difference = abs(value_target_base - prefix.value)
+        if difference < min_difference:
+            min_difference = difference
+            closest_prefix = prefix
+
+    value /= 10 ** closest_prefix.value
+
+    return value * closest_prefix
+
 
 
 # Star-imports *do not* include the single-character names `µ`, `e`, et al.

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -116,9 +116,9 @@ def test_prefix_pow():
     """Test `Prefix` exponentiation"""
     from hdl21.prefix import µ, e
 
-    assert µ**2 == e(-12)
-    assert µ**0.5 == e(-3)
-    assert µ**-1 == e(6)
+    assert µ ** 2 == e(-12)
+    assert µ ** 0.5 == e(-3)
+    assert µ ** -1 == e(6)
 
 
 def test_prefixed_mul():
@@ -226,7 +226,7 @@ def test_e_pow():
     assert (2 * e(-2)) ** 2 == 4 * e(-4)
 
     # Precision-error tests
-    assert (3 * e(4)) ** 0.25, Decimal(3**0.25) * e(1)
+    assert (3 * e(4)) ** 0.25, Decimal(3 ** 0.25) * e(1)
 
 
 def test_e_div():
@@ -415,3 +415,12 @@ def test_prefixed_and_scalar_conversions():
         p = P(x=None, y=2)
     with pt.raises(ValidationError):
         p = P(x=3, y=None)
+
+
+def test_convert_numeric_to_prefix():
+    value = 1e4
+    converted_value = h.prefix.convert_numeric_to_prefix(value)
+    assert 10 * h.prefix.K == converted_value
+    value = 1e-4
+    converted_value = h.prefix.convert_numeric_to_prefix(value)
+    assert 0.1 * h.prefix.m == converted_value


### PR DESCRIPTION
Hi Dan,

Hope you are well! I find this function useful and maybe it could be handy for others.

It works like:

```
value = 1e4
converted_value = h.prefix.convert_numeric_to_prefix(value)
assert 10 * h.prefix.K == converted_value
value = 1e-4
converted_value = h.prefix.convert_numeric_to_prefix(value)
assert 0.1 * h.prefix.m == converted_value
```

I've included this in a test too. Just in case it is of any use.