### PR TITLE
corrected digital cell naming

### DIFF
--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -331,7 +331,12 @@ def _scale_to_smaller(
     and is converted before scaling."""
 
     other = to_prefixed(other)
-    smaller = me.prefix if me.prefix.value < other.prefix.value else other.prefix
+    smaller = (
+        me.prefix
+        if me.number * Decimal(10**me.prefix.value)
+        < other.number * Decimal(10**other.prefix.value)
+        else other.prefix
+    )
     return me.scale(smaller), other.scale(smaller)
 
 

--- a/pdks/Gf180/gf180_hdl21/digital_cells/nine_track.py
+++ b/pdks/Gf180/gf180_hdl21/digital_cells/nine_track.py
@@ -1,1005 +1,1107 @@
 from ..pdk_data import logic_module
 
 addf_1 = logic_module(
-    "addf_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__addf_1",
+    "Nine Track",
     ["A", "B", "CI", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addf_2 = logic_module(
-    "addf_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__addf_2",
+    "Nine Track",
     ["A", "B", "CI", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addf_4 = logic_module(
-    "addf_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__addf_4",
+    "Nine Track",
     ["A", "B", "CI", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addh_1 = logic_module(
-    "addh_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__addh_1",
+    "Nine Track",
     ["A", "B", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addh_2 = logic_module(
-    "addh_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__addh_2",
+    "Nine Track",
     ["A", "B", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addh_4 = logic_module(
-    "addh_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__addh_4",
+    "Nine Track",
     ["A", "B", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 and2_1 = logic_module(
-    "and2_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and2_1",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and2_2 = logic_module(
-    "and2_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and2_2",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and2_4 = logic_module(
-    "and2_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and2_4",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and3_1 = logic_module(
-    "and3_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and3_1",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and3_2 = logic_module(
-    "and3_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and3_2",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and3_4 = logic_module(
-    "and3_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and3_4",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and4_1 = logic_module(
-    "and4_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and4_1",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and4_2 = logic_module(
-    "and4_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and4_2",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and4_4 = logic_module(
-    "and4_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__and4_4",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 antenna = logic_module(
-    "antenna", "gf180mcu_fd_sc_mcu9t5v0", ["I", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__antenna", "Nine Track", ["I", "VDD", "VNW", "VPW", "VSS"]
 )
 aoi21_1 = logic_module(
-    "aoi21_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi21_1",
+    "Nine Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi21_2 = logic_module(
-    "aoi21_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi21_2",
+    "Nine Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi21_4 = logic_module(
-    "aoi21_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi21_4",
+    "Nine Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi22_1 = logic_module(
-    "aoi22_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi22_1",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi22_2 = logic_module(
-    "aoi22_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi22_2",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi22_4 = logic_module(
-    "aoi22_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi22_4",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi211_1 = logic_module(
-    "aoi211_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi211_1",
+    "Nine Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi211_2 = logic_module(
-    "aoi211_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi211_2",
+    "Nine Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi211_4 = logic_module(
-    "aoi211_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi211_4",
+    "Nine Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi221_1 = logic_module(
-    "aoi221_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi221_1",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi221_2 = logic_module(
-    "aoi221_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi221_2",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi221_4 = logic_module(
-    "aoi221_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi221_4",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi222_1 = logic_module(
-    "aoi222_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi222_1",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi222_2 = logic_module(
-    "aoi222_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi222_2",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi222_4 = logic_module(
-    "aoi222_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__aoi222_4",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_1 = logic_module(
-    "buf_1", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__buf_1",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_2 = logic_module(
-    "buf_2", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__buf_2",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_3 = logic_module(
-    "buf_3", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__buf_3",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_4 = logic_module(
-    "buf_4", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__buf_4",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_8 = logic_module(
-    "buf_8", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__buf_8",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_12 = logic_module(
-    "buf_12", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__buf_12",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_16 = logic_module(
-    "buf_16", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__buf_16",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_20 = logic_module(
-    "buf_20", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__buf_20",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_1 = logic_module(
-    "bufz_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__bufz_1",
+    "Nine Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_2 = logic_module(
-    "bufz_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__bufz_2",
+    "Nine Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_3 = logic_module(
-    "bufz_3",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__bufz_3",
+    "Nine Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_4 = logic_module(
-    "bufz_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__bufz_4",
+    "Nine Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_8 = logic_module(
-    "bufz_8",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__bufz_8",
+    "Nine Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_12 = logic_module(
-    "bufz_12",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__bufz_12",
+    "Nine Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_16 = logic_module(
-    "bufz_16",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__bufz_16",
+    "Nine Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_1 = logic_module(
-    "clkbuf_1", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkbuf_1",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_2 = logic_module(
-    "clkbuf_2", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkbuf_2",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_3 = logic_module(
-    "clkbuf_3", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkbuf_3",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_4 = logic_module(
-    "clkbuf_4", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkbuf_4",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_8 = logic_module(
-    "clkbuf_8", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkbuf_8",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_12 = logic_module(
-    "clkbuf_12", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkbuf_12",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_16 = logic_module(
-    "clkbuf_16", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkbuf_16",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_20 = logic_module(
-    "clkbuf_20", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkbuf_20",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_1 = logic_module(
-    "clkinv_1", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkinv_1",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_2 = logic_module(
-    "clkinv_2", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkinv_2",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_3 = logic_module(
-    "clkinv_3", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkinv_3",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_4 = logic_module(
-    "clkinv_4", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkinv_4",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_8 = logic_module(
-    "clkinv_8", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkinv_8",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_12 = logic_module(
-    "clkinv_12", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkinv_12",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_16 = logic_module(
-    "clkinv_16", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkinv_16",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_20 = logic_module(
-    "clkinv_20", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__clkinv_20",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnq_1 = logic_module(
-    "dffnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnq_1",
+    "Nine Track",
     ["D", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnq_2 = logic_module(
-    "dffnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnq_2",
+    "Nine Track",
     ["D", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnq_4 = logic_module(
-    "dffnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnq_4",
+    "Nine Track",
     ["D", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrnq_1 = logic_module(
-    "dffnrnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnrnq_1",
+    "Nine Track",
     ["D", "RN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrnq_2 = logic_module(
-    "dffnrnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnrnq_2",
+    "Nine Track",
     ["D", "RN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrnq_4 = logic_module(
-    "dffnrnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnrnq_4",
+    "Nine Track",
     ["D", "RN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrsnq_1 = logic_module(
-    "dffnrsnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_1",
+    "Nine Track",
     ["D", "RN", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrsnq_2 = logic_module(
-    "dffnrsnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_2",
+    "Nine Track",
     ["D", "RN", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrsnq_4 = logic_module(
-    "dffnrsnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_4",
+    "Nine Track",
     ["D", "RN", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnsnq_1 = logic_module(
-    "dffnsnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnsnq_1",
+    "Nine Track",
     ["D", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnsnq_2 = logic_module(
-    "dffnsnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnsnq_2",
+    "Nine Track",
     ["D", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnsnq_4 = logic_module(
-    "dffnsnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffnsnq_4",
+    "Nine Track",
     ["D", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffq_1 = logic_module(
-    "dffq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffq_1",
+    "Nine Track",
     ["D", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffq_2 = logic_module(
-    "dffq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffq_2",
+    "Nine Track",
     ["D", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffq_4 = logic_module(
-    "dffq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffq_4",
+    "Nine Track",
     ["D", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrnq_1 = logic_module(
-    "dffrnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffrnq_1",
+    "Nine Track",
     ["D", "RN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrnq_2 = logic_module(
-    "dffrnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffrnq_2",
+    "Nine Track",
     ["D", "RN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrnq_4 = logic_module(
-    "dffrnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffrnq_4",
+    "Nine Track",
     ["D", "RN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrsnq_1 = logic_module(
-    "dffrsnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffrsnq_1",
+    "Nine Track",
     ["D", "RN", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrsnq_2 = logic_module(
-    "dffrsnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffrsnq_2",
+    "Nine Track",
     ["D", "RN", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrsnq_4 = logic_module(
-    "dffrsnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffrsnq_4",
+    "Nine Track",
     ["D", "RN", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffsnq_1 = logic_module(
-    "dffsnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffsnq_1",
+    "Nine Track",
     ["D", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffsnq_2 = logic_module(
-    "dffsnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffsnq_2",
+    "Nine Track",
     ["D", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffsnq_4 = logic_module(
-    "dffsnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__dffsnq_4",
+    "Nine Track",
     ["D", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dlya_1 = logic_module(
-    "dlya_1", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlya_1",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlya_2 = logic_module(
-    "dlya_2", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlya_2",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlya_4 = logic_module(
-    "dlya_4", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlya_4",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyb_1 = logic_module(
-    "dlyb_1", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyb_1",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyb_2 = logic_module(
-    "dlyb_2", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyb_2",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyb_4 = logic_module(
-    "dlyb_4", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyb_4",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyc_1 = logic_module(
-    "dlyc_1", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyc_1",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyc_2 = logic_module(
-    "dlyc_2", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyc_2",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyc_4 = logic_module(
-    "dlyc_4", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyc_4",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyd_1 = logic_module(
-    "dlyd_1", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyd_1",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyd_2 = logic_module(
-    "dlyd_2", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyd_2",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyd_4 = logic_module(
-    "dlyd_4", "gf180mcu_fd_sc_mcu9t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__dlyd_4",
+    "Nine Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
-endcap = logic_module("endcap", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VSS"])
-fill_1 = logic_module("fill_1", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"])
-fill_2 = logic_module("fill_2", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"])
-fill_4 = logic_module("fill_4", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"])
-fill_8 = logic_module("fill_8", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"])
+endcap = logic_module("gf180mcu_fd_sc_mcu9t5v0__endcap", "Nine Track", ["VDD", "VSS"])
+fill_1 = logic_module(
+    "gf180mcu_fd_sc_mcu9t5v0__fill_1", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
+)
+fill_2 = logic_module(
+    "gf180mcu_fd_sc_mcu9t5v0__fill_2", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
+)
+fill_4 = logic_module(
+    "gf180mcu_fd_sc_mcu9t5v0__fill_4", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
+)
+fill_8 = logic_module(
+    "gf180mcu_fd_sc_mcu9t5v0__fill_8", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
+)
 fill_16 = logic_module(
-    "fill_16", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__fill_16", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fill_32 = logic_module(
-    "fill_32", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__fill_32", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fill_64 = logic_module(
-    "fill_64", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__fill_64", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_4 = logic_module(
-    "fillcap_4", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__fillcap_4", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_8 = logic_module(
-    "fillcap_8", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__fillcap_8", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_16 = logic_module(
-    "fillcap_16", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__fillcap_16", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_32 = logic_module(
-    "fillcap_32", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__fillcap_32", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_64 = logic_module(
-    "fillcap_64", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__fillcap_64", "Nine Track", ["VDD", "VNW", "VPW", "VSS"]
 )
-filltie = logic_module("filltie", "gf180mcu_fd_sc_mcu9t5v0", ["VDD", "VSS"])
+filltie = logic_module("gf180mcu_fd_sc_mcu9t5v0__filltie", "Nine Track", ["VDD", "VSS"])
 hold = logic_module(
-    "hold", "gf180mcu_fd_sc_mcu9t5v0", ["Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__hold", "Nine Track", ["Z", "VDD", "VNW", "VPW", "VSS"]
 )
 icgtn_1 = logic_module(
-    "icgtn_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__icgtn_1",
+    "Nine Track",
     ["CLKN", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtn_2 = logic_module(
-    "icgtn_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__icgtn_2",
+    "Nine Track",
     ["CLKN", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtn_4 = logic_module(
-    "icgtn_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__icgtn_4",
+    "Nine Track",
     ["CLKN", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtp_1 = logic_module(
-    "icgtp_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__icgtp_1",
+    "Nine Track",
     ["CLK", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtp_2 = logic_module(
-    "icgtp_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__icgtp_2",
+    "Nine Track",
     ["CLK", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtp_4 = logic_module(
-    "icgtp_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__icgtp_4",
+    "Nine Track",
     ["CLK", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_1 = logic_module(
-    "inv_1", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__inv_1",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_2 = logic_module(
-    "inv_2", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__inv_2",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_3 = logic_module(
-    "inv_3", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__inv_3",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_4 = logic_module(
-    "inv_4", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__inv_4",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_8 = logic_module(
-    "inv_8", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__inv_8",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_12 = logic_module(
-    "inv_12", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__inv_12",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_16 = logic_module(
-    "inv_16", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__inv_16",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_20 = logic_module(
-    "inv_20", "gf180mcu_fd_sc_mcu9t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__inv_20",
+    "Nine Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_1 = logic_module(
-    "invz_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__invz_1",
+    "Nine Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_2 = logic_module(
-    "invz_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__invz_2",
+    "Nine Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_3 = logic_module(
-    "invz_3",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__invz_3",
+    "Nine Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_4 = logic_module(
-    "invz_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__invz_4",
+    "Nine Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_8 = logic_module(
-    "invz_8",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__invz_8",
+    "Nine Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_12 = logic_module(
-    "invz_12",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__invz_12",
+    "Nine Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_16 = logic_module(
-    "invz_16",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__invz_16",
+    "Nine Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 latq_1 = logic_module(
-    "latq_1", "gf180mcu_fd_sc_mcu9t5v0", ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__latq_1",
+    "Nine Track",
+    ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latq_2 = logic_module(
-    "latq_2", "gf180mcu_fd_sc_mcu9t5v0", ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__latq_2",
+    "Nine Track",
+    ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latq_4 = logic_module(
-    "latq_4", "gf180mcu_fd_sc_mcu9t5v0", ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__latq_4",
+    "Nine Track",
+    ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrnq_1 = logic_module(
-    "latrnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latrnq_1",
+    "Nine Track",
     ["D", "E", "RN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrnq_2 = logic_module(
-    "latrnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latrnq_2",
+    "Nine Track",
     ["D", "E", "RN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrnq_4 = logic_module(
-    "latrnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latrnq_4",
+    "Nine Track",
     ["D", "E", "RN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrsnq_1 = logic_module(
-    "latrsnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latrsnq_1",
+    "Nine Track",
     ["D", "E", "RN", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrsnq_2 = logic_module(
-    "latrsnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latrsnq_2",
+    "Nine Track",
     ["D", "E", "RN", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrsnq_4 = logic_module(
-    "latrsnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latrsnq_4",
+    "Nine Track",
     ["D", "E", "RN", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latsnq_1 = logic_module(
-    "latsnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latsnq_1",
+    "Nine Track",
     ["D", "E", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latsnq_2 = logic_module(
-    "latsnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latsnq_2",
+    "Nine Track",
     ["D", "E", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latsnq_4 = logic_module(
-    "latsnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__latsnq_4",
+    "Nine Track",
     ["D", "E", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 mux2_1 = logic_module(
-    "mux2_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__mux2_1",
+    "Nine Track",
     ["I0", "I1", "S", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux2_2 = logic_module(
-    "mux2_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__mux2_2",
+    "Nine Track",
     ["I0", "I1", "S", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux2_4 = logic_module(
-    "mux2_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__mux2_4",
+    "Nine Track",
     ["I0", "I1", "S", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux4_1 = logic_module(
-    "mux4_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__mux4_1",
+    "Nine Track",
     ["I0", "I1", "I2", "I3", "S0", "S1", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux4_2 = logic_module(
-    "mux4_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__mux4_2",
+    "Nine Track",
     ["I0", "I1", "I2", "I3", "S0", "S1", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux4_4 = logic_module(
-    "mux4_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__mux4_4",
+    "Nine Track",
     ["I0", "I1", "I2", "I3", "S0", "S1", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 nand2_1 = logic_module(
-    "nand2_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand2_1",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand2_2 = logic_module(
-    "nand2_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand2_2",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand2_4 = logic_module(
-    "nand2_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand2_4",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand3_1 = logic_module(
-    "nand3_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand3_1",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand3_2 = logic_module(
-    "nand3_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand3_2",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand3_4 = logic_module(
-    "nand3_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand3_4",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand4_1 = logic_module(
-    "nand4_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand4_1",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand4_2 = logic_module(
-    "nand4_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand4_2",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand4_4 = logic_module(
-    "nand4_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nand4_4",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor2_1 = logic_module(
-    "nor2_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor2_1",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor2_2 = logic_module(
-    "nor2_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor2_2",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor2_4 = logic_module(
-    "nor2_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor2_4",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor3_1 = logic_module(
-    "nor3_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor3_1",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor3_2 = logic_module(
-    "nor3_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor3_2",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor3_4 = logic_module(
-    "nor3_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor3_4",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor4_1 = logic_module(
-    "nor4_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor4_1",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor4_2 = logic_module(
-    "nor4_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor4_2",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor4_4 = logic_module(
-    "nor4_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__nor4_4",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai21_1 = logic_module(
-    "oai21_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai21_1",
+    "Nine Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai21_2 = logic_module(
-    "oai21_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai21_2",
+    "Nine Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai21_4 = logic_module(
-    "oai21_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai21_4",
+    "Nine Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai22_1 = logic_module(
-    "oai22_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai22_1",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai22_2 = logic_module(
-    "oai22_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai22_2",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai22_4 = logic_module(
-    "oai22_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai22_4",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai31_1 = logic_module(
-    "oai31_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai31_1",
+    "Nine Track",
     ["A1", "A2", "A3", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai31_2 = logic_module(
-    "oai31_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai31_2",
+    "Nine Track",
     ["A1", "A2", "A3", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai31_4 = logic_module(
-    "oai31_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai31_4",
+    "Nine Track",
     ["A1", "A2", "A3", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai32_1 = logic_module(
-    "oai32_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai32_1",
+    "Nine Track",
     ["A1", "A2", "A3", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai32_2 = logic_module(
-    "oai32_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai32_2",
+    "Nine Track",
     ["A1", "A2", "A3", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai32_4 = logic_module(
-    "oai32_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai32_4",
+    "Nine Track",
     ["A1", "A2", "A3", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai33_1 = logic_module(
-    "oai33_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai33_1",
+    "Nine Track",
     ["A1", "A2", "A3", "B1", "B2", "B3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai33_2 = logic_module(
-    "oai33_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai33_2",
+    "Nine Track",
     ["A1", "A2", "A3", "B1", "B2", "B3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai33_4 = logic_module(
-    "oai33_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai33_4",
+    "Nine Track",
     ["A1", "A2", "A3", "B1", "B2", "B3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai211_1 = logic_module(
-    "oai211_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai211_1",
+    "Nine Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai211_2 = logic_module(
-    "oai211_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai211_2",
+    "Nine Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai211_4 = logic_module(
-    "oai211_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai211_4",
+    "Nine Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai221_1 = logic_module(
-    "oai221_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai221_1",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai221_2 = logic_module(
-    "oai221_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai221_2",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai221_4 = logic_module(
-    "oai221_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai221_4",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai222_1 = logic_module(
-    "oai222_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai222_1",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai222_2 = logic_module(
-    "oai222_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai222_2",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai222_4 = logic_module(
-    "oai222_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__oai222_4",
+    "Nine Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 or2_1 = logic_module(
-    "or2_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or2_1",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or2_2 = logic_module(
-    "or2_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or2_2",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or2_4 = logic_module(
-    "or2_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or2_4",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or3_1 = logic_module(
-    "or3_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or3_1",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or3_2 = logic_module(
-    "or3_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or3_2",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or3_4 = logic_module(
-    "or3_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or3_4",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or4_1 = logic_module(
-    "or4_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or4_1",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or4_2 = logic_module(
-    "or4_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or4_2",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or4_4 = logic_module(
-    "or4_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__or4_4",
+    "Nine Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffq_1 = logic_module(
-    "sdffq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffq_1",
+    "Nine Track",
     ["D", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffq_2 = logic_module(
-    "sdffq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffq_2",
+    "Nine Track",
     ["D", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffq_4 = logic_module(
-    "sdffq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffq_4",
+    "Nine Track",
     ["D", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrnq_1 = logic_module(
-    "sdffrnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1",
+    "Nine Track",
     ["D", "RN", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrnq_2 = logic_module(
-    "sdffrnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2",
+    "Nine Track",
     ["D", "RN", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrnq_4 = logic_module(
-    "sdffrnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4",
+    "Nine Track",
     ["D", "RN", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrsnq_1 = logic_module(
-    "sdffrsnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1",
+    "Nine Track",
     ["D", "RN", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrsnq_2 = logic_module(
-    "sdffrsnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2",
+    "Nine Track",
     ["D", "RN", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrsnq_4 = logic_module(
-    "sdffrsnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4",
+    "Nine Track",
     ["D", "RN", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffsnq_1 = logic_module(
-    "sdffsnq_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1",
+    "Nine Track",
     ["D", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffsnq_2 = logic_module(
-    "sdffsnq_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2",
+    "Nine Track",
     ["D", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffsnq_4 = logic_module(
-    "sdffsnq_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4",
+    "Nine Track",
     ["D", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 tieh = logic_module(
-    "tieh", "gf180mcu_fd_sc_mcu9t5v0", ["Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__tieh", "Nine Track", ["Z", "VDD", "VNW", "VPW", "VSS"]
 )
 tiel = logic_module(
-    "tiel", "gf180mcu_fd_sc_mcu9t5v0", ["ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu9t5v0__tiel", "Nine Track", ["ZN", "VDD", "VNW", "VPW", "VSS"]
 )
 xnor2_1 = logic_module(
-    "xnor2_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xnor2_1",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor2_2 = logic_module(
-    "xnor2_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xnor2_2",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor2_4 = logic_module(
-    "xnor2_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xnor2_4",
+    "Nine Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor3_1 = logic_module(
-    "xnor3_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xnor3_1",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor3_2 = logic_module(
-    "xnor3_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xnor3_2",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor3_4 = logic_module(
-    "xnor3_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xnor3_4",
+    "Nine Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xor2_1 = logic_module(
-    "xor2_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xor2_1",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor2_2 = logic_module(
-    "xor2_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xor2_2",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor2_4 = logic_module(
-    "xor2_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xor2_4",
+    "Nine Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor3_1 = logic_module(
-    "xor3_1",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xor3_1",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor3_2 = logic_module(
-    "xor3_2",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xor3_2",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor3_4 = logic_module(
-    "xor3_4",
-    "gf180mcu_fd_sc_mcu9t5v0",
+    "gf180mcu_fd_sc_mcu9t5v0__xor3_4",
+    "Nine Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )

--- a/pdks/Gf180/gf180_hdl21/digital_cells/seven_track.py
+++ b/pdks/Gf180/gf180_hdl21/digital_cells/seven_track.py
@@ -1,1005 +1,1109 @@
 from ..pdk_data import logic_module
 
 addf_1 = logic_module(
-    "addf_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__addf_1",
+    "Seven Track",
     ["A", "B", "CI", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addf_2 = logic_module(
-    "addf_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__addf_2",
+    "Seven Track",
     ["A", "B", "CI", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addf_4 = logic_module(
-    "addf_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__addf_4",
+    "Seven Track",
     ["A", "B", "CI", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addh_1 = logic_module(
-    "addh_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__addh_1",
+    "Seven Track",
     ["A", "B", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addh_2 = logic_module(
-    "addh_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__addh_2",
+    "Seven Track",
     ["A", "B", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 addh_4 = logic_module(
-    "addh_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__addh_4",
+    "Seven Track",
     ["A", "B", "CO", "S", "VDD", "VNW", "VPW", "VSS"],
 )
 and2_1 = logic_module(
-    "and2_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and2_1",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and2_2 = logic_module(
-    "and2_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and2_2",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and2_4 = logic_module(
-    "and2_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and2_4",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and3_1 = logic_module(
-    "and3_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and3_1",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and3_2 = logic_module(
-    "and3_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and3_2",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and3_4 = logic_module(
-    "and3_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and3_4",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and4_1 = logic_module(
-    "and4_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and4_1",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and4_2 = logic_module(
-    "and4_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and4_2",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 and4_4 = logic_module(
-    "and4_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__and4_4",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 antenna = logic_module(
-    "antenna", "gf180mcu_fd_sc_mcu7t5v0", ["I", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__antenna", "Seven Track", ["I", "VDD", "VNW", "VPW", "VSS"]
 )
 aoi21_1 = logic_module(
-    "aoi21_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi21_1",
+    "Seven Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi21_2 = logic_module(
-    "aoi21_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi21_2",
+    "Seven Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi21_4 = logic_module(
-    "aoi21_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi21_4",
+    "Seven Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi22_1 = logic_module(
-    "aoi22_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi22_1",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi22_2 = logic_module(
-    "aoi22_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi22_2",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi22_4 = logic_module(
-    "aoi22_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi22_4",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi211_1 = logic_module(
-    "aoi211_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi211_1",
+    "Seven Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi211_2 = logic_module(
-    "aoi211_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi211_2",
+    "Seven Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi211_4 = logic_module(
-    "aoi211_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi211_4",
+    "Seven Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi221_1 = logic_module(
-    "aoi221_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi221_1",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi221_2 = logic_module(
-    "aoi221_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi221_2",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi221_4 = logic_module(
-    "aoi221_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi221_4",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi222_1 = logic_module(
-    "aoi222_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi222_1",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi222_2 = logic_module(
-    "aoi222_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi222_2",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 aoi222_4 = logic_module(
-    "aoi222_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__aoi222_4",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_1 = logic_module(
-    "buf_1", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__buf_1",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_2 = logic_module(
-    "buf_2", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__buf_2",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_3 = logic_module(
-    "buf_3", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__buf_3",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_4 = logic_module(
-    "buf_4", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__buf_4",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_8 = logic_module(
-    "buf_8", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__buf_8",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_12 = logic_module(
-    "buf_12", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__buf_12",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_16 = logic_module(
-    "buf_16", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__buf_16",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 buf_20 = logic_module(
-    "buf_20", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__buf_20",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_1 = logic_module(
-    "bufz_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__bufz_1",
+    "Seven Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_2 = logic_module(
-    "bufz_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__bufz_2",
+    "Seven Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_3 = logic_module(
-    "bufz_3",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__bufz_3",
+    "Seven Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_4 = logic_module(
-    "bufz_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__bufz_4",
+    "Seven Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_8 = logic_module(
-    "bufz_8",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__bufz_8",
+    "Seven Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_12 = logic_module(
-    "bufz_12",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__bufz_12",
+    "Seven Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 bufz_16 = logic_module(
-    "bufz_16",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__bufz_16",
+    "Seven Track",
     ["EN", "I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_1 = logic_module(
-    "clkbuf_1", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkbuf_1",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_2 = logic_module(
-    "clkbuf_2", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkbuf_2",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_3 = logic_module(
-    "clkbuf_3", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkbuf_3",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_4 = logic_module(
-    "clkbuf_4", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkbuf_4",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_8 = logic_module(
-    "clkbuf_8", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkbuf_8",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_12 = logic_module(
-    "clkbuf_12", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkbuf_12",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_16 = logic_module(
-    "clkbuf_16", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkbuf_16",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkbuf_20 = logic_module(
-    "clkbuf_20", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkbuf_20",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_1 = logic_module(
-    "clkinv_1", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkinv_1",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_2 = logic_module(
-    "clkinv_2", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkinv_2",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_3 = logic_module(
-    "clkinv_3", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkinv_3",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_4 = logic_module(
-    "clkinv_4", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkinv_4",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_8 = logic_module(
-    "clkinv_8", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkinv_8",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_12 = logic_module(
-    "clkinv_12", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkinv_12",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_16 = logic_module(
-    "clkinv_16", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkinv_16",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 clkinv_20 = logic_module(
-    "clkinv_20", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__clkinv_20",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnq_1 = logic_module(
-    "dffnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnq_1",
+    "Seven Track",
     ["D", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnq_2 = logic_module(
-    "dffnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnq_2",
+    "Seven Track",
     ["D", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnq_4 = logic_module(
-    "dffnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnq_4",
+    "Seven Track",
     ["D", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrnq_1 = logic_module(
-    "dffnrnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnrnq_1",
+    "Seven Track",
     ["D", "RN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrnq_2 = logic_module(
-    "dffnrnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnrnq_2",
+    "Seven Track",
     ["D", "RN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrnq_4 = logic_module(
-    "dffnrnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnrnq_4",
+    "Seven Track",
     ["D", "RN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrsnq_1 = logic_module(
-    "dffnrsnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_1",
+    "Seven Track",
     ["D", "RN", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrsnq_2 = logic_module(
-    "dffnrsnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_2",
+    "Seven Track",
     ["D", "RN", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnrsnq_4 = logic_module(
-    "dffnrsnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_4",
+    "Seven Track",
     ["D", "RN", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnsnq_1 = logic_module(
-    "dffnsnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnsnq_1",
+    "Seven Track",
     ["D", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnsnq_2 = logic_module(
-    "dffnsnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnsnq_2",
+    "Seven Track",
     ["D", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffnsnq_4 = logic_module(
-    "dffnsnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffnsnq_4",
+    "Seven Track",
     ["D", "SETN", "CLKN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffq_1 = logic_module(
-    "dffq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffq_1",
+    "Seven Track",
     ["D", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffq_2 = logic_module(
-    "dffq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffq_2",
+    "Seven Track",
     ["D", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffq_4 = logic_module(
-    "dffq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffq_4",
+    "Seven Track",
     ["D", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrnq_1 = logic_module(
-    "dffrnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffrnq_1",
+    "Seven Track",
     ["D", "RN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrnq_2 = logic_module(
-    "dffrnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffrnq_2",
+    "Seven Track",
     ["D", "RN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrnq_4 = logic_module(
-    "dffrnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffrnq_4",
+    "Seven Track",
     ["D", "RN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrsnq_1 = logic_module(
-    "dffrsnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffrsnq_1",
+    "Seven Track",
     ["D", "RN", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrsnq_2 = logic_module(
-    "dffrsnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffrsnq_2",
+    "Seven Track",
     ["D", "RN", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffrsnq_4 = logic_module(
-    "dffrsnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffrsnq_4",
+    "Seven Track",
     ["D", "RN", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffsnq_1 = logic_module(
-    "dffsnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffsnq_1",
+    "Seven Track",
     ["D", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffsnq_2 = logic_module(
-    "dffsnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffsnq_2",
+    "Seven Track",
     ["D", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dffsnq_4 = logic_module(
-    "dffsnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__dffsnq_4",
+    "Seven Track",
     ["D", "SETN", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 dlya_1 = logic_module(
-    "dlya_1", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlya_1",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlya_2 = logic_module(
-    "dlya_2", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlya_2",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlya_4 = logic_module(
-    "dlya_4", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlya_4",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyb_1 = logic_module(
-    "dlyb_1", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyb_1",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyb_2 = logic_module(
-    "dlyb_2", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyb_2",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyb_4 = logic_module(
-    "dlyb_4", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyb_4",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyc_1 = logic_module(
-    "dlyc_1", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyc_1",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyc_2 = logic_module(
-    "dlyc_2", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyc_2",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyc_4 = logic_module(
-    "dlyc_4", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyc_4",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyd_1 = logic_module(
-    "dlyd_1", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyd_1",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyd_2 = logic_module(
-    "dlyd_2", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyd_2",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 dlyd_4 = logic_module(
-    "dlyd_4", "gf180mcu_fd_sc_mcu7t5v0", ["I", "Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__dlyd_4",
+    "Seven Track",
+    ["I", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
-endcap = logic_module("endcap", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VSS"])
-fill_1 = logic_module("fill_1", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"])
-fill_2 = logic_module("fill_2", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"])
-fill_4 = logic_module("fill_4", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"])
-fill_8 = logic_module("fill_8", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"])
+endcap = logic_module("gf180mcu_fd_sc_mcu7t5v0__endcap", "Seven Track", ["VDD", "VSS"])
+fill_1 = logic_module(
+    "gf180mcu_fd_sc_mcu7t5v0__fill_1", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
+)
+fill_2 = logic_module(
+    "gf180mcu_fd_sc_mcu7t5v0__fill_2", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
+)
+fill_4 = logic_module(
+    "gf180mcu_fd_sc_mcu7t5v0__fill_4", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
+)
+fill_8 = logic_module(
+    "gf180mcu_fd_sc_mcu7t5v0__fill_8", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
+)
 fill_16 = logic_module(
-    "fill_16", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__fill_16", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fill_32 = logic_module(
-    "fill_32", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__fill_32", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fill_64 = logic_module(
-    "fill_64", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__fill_64", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_4 = logic_module(
-    "fillcap_4", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__fillcap_4", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_8 = logic_module(
-    "fillcap_8", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__fillcap_8", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_16 = logic_module(
-    "fillcap_16", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__fillcap_16", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_32 = logic_module(
-    "fillcap_32", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__fillcap_32", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
 )
 fillcap_64 = logic_module(
-    "fillcap_64", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__fillcap_64", "Seven Track", ["VDD", "VNW", "VPW", "VSS"]
 )
-filltie = logic_module("filltie", "gf180mcu_fd_sc_mcu7t5v0", ["VDD", "VSS"])
+filltie = logic_module(
+    "gf180mcu_fd_sc_mcu7t5v0__filltie", "Seven Track", ["VDD", "VSS"]
+)
 hold = logic_module(
-    "hold", "gf180mcu_fd_sc_mcu7t5v0", ["Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__hold", "Seven Track", ["Z", "VDD", "VNW", "VPW", "VSS"]
 )
 icgtn_1 = logic_module(
-    "icgtn_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__icgtn_1",
+    "Seven Track",
     ["CLKN", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtn_2 = logic_module(
-    "icgtn_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__icgtn_2",
+    "Seven Track",
     ["CLKN", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtn_4 = logic_module(
-    "icgtn_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__icgtn_4",
+    "Seven Track",
     ["CLKN", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtp_1 = logic_module(
-    "icgtp_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__icgtp_1",
+    "Seven Track",
     ["CLK", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtp_2 = logic_module(
-    "icgtp_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__icgtp_2",
+    "Seven Track",
     ["CLK", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 icgtp_4 = logic_module(
-    "icgtp_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__icgtp_4",
+    "Seven Track",
     ["CLK", "E", "TE", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_1 = logic_module(
-    "inv_1", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__inv_1",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_2 = logic_module(
-    "inv_2", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__inv_2",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_3 = logic_module(
-    "inv_3", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__inv_3",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_4 = logic_module(
-    "inv_4", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__inv_4",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_8 = logic_module(
-    "inv_8", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__inv_8",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_12 = logic_module(
-    "inv_12", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__inv_12",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_16 = logic_module(
-    "inv_16", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__inv_16",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 inv_20 = logic_module(
-    "inv_20", "gf180mcu_fd_sc_mcu7t5v0", ["I", "ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__inv_20",
+    "Seven Track",
+    ["I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_1 = logic_module(
-    "invz_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__invz_1",
+    "Seven Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_2 = logic_module(
-    "invz_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__invz_2",
+    "Seven Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_3 = logic_module(
-    "invz_3",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__invz_3",
+    "Seven Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_4 = logic_module(
-    "invz_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__invz_4",
+    "Seven Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_8 = logic_module(
-    "invz_8",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__invz_8",
+    "Seven Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_12 = logic_module(
-    "invz_12",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__invz_12",
+    "Seven Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 invz_16 = logic_module(
-    "invz_16",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__invz_16",
+    "Seven Track",
     ["EN", "I", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 latq_1 = logic_module(
-    "latq_1", "gf180mcu_fd_sc_mcu7t5v0", ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__latq_1",
+    "Seven Track",
+    ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latq_2 = logic_module(
-    "latq_2", "gf180mcu_fd_sc_mcu7t5v0", ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__latq_2",
+    "Seven Track",
+    ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latq_4 = logic_module(
-    "latq_4", "gf180mcu_fd_sc_mcu7t5v0", ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__latq_4",
+    "Seven Track",
+    ["D", "E", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrnq_1 = logic_module(
-    "latrnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latrnq_1",
+    "Seven Track",
     ["D", "E", "RN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrnq_2 = logic_module(
-    "latrnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latrnq_2",
+    "Seven Track",
     ["D", "E", "RN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrnq_4 = logic_module(
-    "latrnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latrnq_4",
+    "Seven Track",
     ["D", "E", "RN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrsnq_1 = logic_module(
-    "latrsnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latrsnq_1",
+    "Seven Track",
     ["D", "E", "RN", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrsnq_2 = logic_module(
-    "latrsnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latrsnq_2",
+    "Seven Track",
     ["D", "E", "RN", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latrsnq_4 = logic_module(
-    "latrsnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latrsnq_4",
+    "Seven Track",
     ["D", "E", "RN", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latsnq_1 = logic_module(
-    "latsnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latsnq_1",
+    "Seven Track",
     ["D", "E", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latsnq_2 = logic_module(
-    "latsnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latsnq_2",
+    "Seven Track",
     ["D", "E", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 latsnq_4 = logic_module(
-    "latsnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__latsnq_4",
+    "Seven Track",
     ["D", "E", "SETN", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 mux2_1 = logic_module(
-    "mux2_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__mux2_1",
+    "Seven Track",
     ["I0", "I1", "S", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux2_2 = logic_module(
-    "mux2_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__mux2_2",
+    "Seven Track",
     ["I0", "I1", "S", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux2_4 = logic_module(
-    "mux2_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__mux2_4",
+    "Seven Track",
     ["I0", "I1", "S", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux4_1 = logic_module(
-    "mux4_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__mux4_1",
+    "Seven Track",
     ["I0", "I1", "I2", "I3", "S0", "S1", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux4_2 = logic_module(
-    "mux4_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__mux4_2",
+    "Seven Track",
     ["I0", "I1", "I2", "I3", "S0", "S1", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 mux4_4 = logic_module(
-    "mux4_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__mux4_4",
+    "Seven Track",
     ["I0", "I1", "I2", "I3", "S0", "S1", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 nand2_1 = logic_module(
-    "nand2_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand2_1",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand2_2 = logic_module(
-    "nand2_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand2_2",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand2_4 = logic_module(
-    "nand2_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand2_4",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand3_1 = logic_module(
-    "nand3_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand3_1",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand3_2 = logic_module(
-    "nand3_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand3_2",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand3_4 = logic_module(
-    "nand3_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand3_4",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand4_1 = logic_module(
-    "nand4_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand4_1",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand4_2 = logic_module(
-    "nand4_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand4_2",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nand4_4 = logic_module(
-    "nand4_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nand4_4",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor2_1 = logic_module(
-    "nor2_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor2_1",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor2_2 = logic_module(
-    "nor2_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor2_2",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor2_4 = logic_module(
-    "nor2_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor2_4",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor3_1 = logic_module(
-    "nor3_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor3_1",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor3_2 = logic_module(
-    "nor3_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor3_2",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor3_4 = logic_module(
-    "nor3_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor3_4",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor4_1 = logic_module(
-    "nor4_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor4_1",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor4_2 = logic_module(
-    "nor4_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor4_2",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 nor4_4 = logic_module(
-    "nor4_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__nor4_4",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai21_1 = logic_module(
-    "oai21_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai21_1",
+    "Seven Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai21_2 = logic_module(
-    "oai21_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai21_2",
+    "Seven Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai21_4 = logic_module(
-    "oai21_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai21_4",
+    "Seven Track",
     ["A1", "A2", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai22_1 = logic_module(
-    "oai22_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai22_1",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai22_2 = logic_module(
-    "oai22_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai22_2",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai22_4 = logic_module(
-    "oai22_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai22_4",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai31_1 = logic_module(
-    "oai31_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai31_1",
+    "Seven Track",
     ["A1", "A2", "A3", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai31_2 = logic_module(
-    "oai31_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai31_2",
+    "Seven Track",
     ["A1", "A2", "A3", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai31_4 = logic_module(
-    "oai31_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai31_4",
+    "Seven Track",
     ["A1", "A2", "A3", "B", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai32_1 = logic_module(
-    "oai32_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai32_1",
+    "Seven Track",
     ["A1", "A2", "A3", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai32_2 = logic_module(
-    "oai32_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai32_2",
+    "Seven Track",
     ["A1", "A2", "A3", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai32_4 = logic_module(
-    "oai32_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai32_4",
+    "Seven Track",
     ["A1", "A2", "A3", "B1", "B2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai33_1 = logic_module(
-    "oai33_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai33_1",
+    "Seven Track",
     ["A1", "A2", "A3", "B1", "B2", "B3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai33_2 = logic_module(
-    "oai33_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai33_2",
+    "Seven Track",
     ["A1", "A2", "A3", "B1", "B2", "B3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai33_4 = logic_module(
-    "oai33_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai33_4",
+    "Seven Track",
     ["A1", "A2", "A3", "B1", "B2", "B3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai211_1 = logic_module(
-    "oai211_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai211_1",
+    "Seven Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai211_2 = logic_module(
-    "oai211_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai211_2",
+    "Seven Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai211_4 = logic_module(
-    "oai211_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai211_4",
+    "Seven Track",
     ["A1", "A2", "B", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai221_1 = logic_module(
-    "oai221_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai221_1",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai221_2 = logic_module(
-    "oai221_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai221_2",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai221_4 = logic_module(
-    "oai221_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai221_4",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai222_1 = logic_module(
-    "oai222_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai222_1",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai222_2 = logic_module(
-    "oai222_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai222_2",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 oai222_4 = logic_module(
-    "oai222_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__oai222_4",
+    "Seven Track",
     ["A1", "A2", "B1", "B2", "C1", "C2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 or2_1 = logic_module(
-    "or2_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or2_1",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or2_2 = logic_module(
-    "or2_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or2_2",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or2_4 = logic_module(
-    "or2_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or2_4",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or3_1 = logic_module(
-    "or3_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or3_1",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or3_2 = logic_module(
-    "or3_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or3_2",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or3_4 = logic_module(
-    "or3_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or3_4",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or4_1 = logic_module(
-    "or4_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or4_1",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or4_2 = logic_module(
-    "or4_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or4_2",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 or4_4 = logic_module(
-    "or4_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__or4_4",
+    "Seven Track",
     ["A1", "A2", "A3", "A4", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffq_1 = logic_module(
-    "sdffq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffq_1",
+    "Seven Track",
     ["D", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffq_2 = logic_module(
-    "sdffq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffq_2",
+    "Seven Track",
     ["D", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffq_4 = logic_module(
-    "sdffq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffq_4",
+    "Seven Track",
     ["D", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrnq_1 = logic_module(
-    "sdffrnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1",
+    "Seven Track",
     ["D", "RN", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrnq_2 = logic_module(
-    "sdffrnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2",
+    "Seven Track",
     ["D", "RN", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrnq_4 = logic_module(
-    "sdffrnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4",
+    "Seven Track",
     ["D", "RN", "SE", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrsnq_1 = logic_module(
-    "sdffrsnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1",
+    "Seven Track",
     ["D", "RN", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrsnq_2 = logic_module(
-    "sdffrsnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2",
+    "Seven Track",
     ["D", "RN", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffrsnq_4 = logic_module(
-    "sdffrsnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4",
+    "Seven Track",
     ["D", "RN", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffsnq_1 = logic_module(
-    "sdffsnq_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1",
+    "Seven Track",
     ["D", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffsnq_2 = logic_module(
-    "sdffsnq_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2",
+    "Seven Track",
     ["D", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 sdffsnq_4 = logic_module(
-    "sdffsnq_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4",
+    "Seven Track",
     ["D", "SE", "SETN", "SI", "CLK", "Q", "VDD", "VNW", "VPW", "VSS"],
 )
 tieh = logic_module(
-    "tieh", "gf180mcu_fd_sc_mcu7t5v0", ["Z", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__tieh", "Seven Track", ["Z", "VDD", "VNW", "VPW", "VSS"]
 )
 tiel = logic_module(
-    "tiel", "gf180mcu_fd_sc_mcu7t5v0", ["ZN", "VDD", "VNW", "VPW", "VSS"]
+    "gf180mcu_fd_sc_mcu7t5v0__tiel", "Seven Track", ["ZN", "VDD", "VNW", "VPW", "VSS"]
 )
 xnor2_1 = logic_module(
-    "xnor2_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xnor2_1",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor2_2 = logic_module(
-    "xnor2_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xnor2_2",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor2_4 = logic_module(
-    "xnor2_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xnor2_4",
+    "Seven Track",
     ["A1", "A2", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor3_1 = logic_module(
-    "xnor3_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xnor3_1",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor3_2 = logic_module(
-    "xnor3_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xnor3_2",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xnor3_4 = logic_module(
-    "xnor3_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xnor3_4",
+    "Seven Track",
     ["A1", "A2", "A3", "ZN", "VDD", "VNW", "VPW", "VSS"],
 )
 xor2_1 = logic_module(
-    "xor2_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xor2_1",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor2_2 = logic_module(
-    "xor2_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xor2_2",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor2_4 = logic_module(
-    "xor2_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xor2_4",
+    "Seven Track",
     ["A1", "A2", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor3_1 = logic_module(
-    "xor3_1",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xor3_1",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor3_2 = logic_module(
-    "xor3_2",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xor3_2",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )
 xor3_4 = logic_module(
-    "xor3_4",
-    "gf180mcu_fd_sc_mcu7t5v0",
+    "gf180mcu_fd_sc_mcu7t5v0__xor3_4",
+    "Seven Track",
     ["A1", "A2", "A3", "Z", "VDD", "VNW", "VPW", "VSS"],
 )

--- a/pdks/Sky130/sky130_hdl21/digital_cells/high_density.py
+++ b/pdks/Sky130/sky130_hdl21/digital_cells/high_density.py
@@ -1,1946 +1,1964 @@
 from ..pdk_data import logic_module
 
 a2bb2o_1 = logic_module(
-    "a2bb2o_1",
+    "sky130_fd_sc_hd__a2bb2o_1",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_2 = logic_module(
-    "a2bb2o_2",
+    "sky130_fd_sc_hd__a2bb2o_2",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_4 = logic_module(
-    "a2bb2o_4",
+    "sky130_fd_sc_hd__a2bb2o_4",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2oi_1 = logic_module(
-    "a2bb2oi_1",
+    "sky130_fd_sc_hd__a2bb2oi_1",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_2 = logic_module(
-    "a2bb2oi_2",
+    "sky130_fd_sc_hd__a2bb2oi_2",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_4 = logic_module(
-    "a2bb2oi_4",
+    "sky130_fd_sc_hd__a2bb2oi_4",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21bo_1 = logic_module(
-    "a21bo_1",
+    "sky130_fd_sc_hd__a21bo_1",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_2 = logic_module(
-    "a21bo_2",
+    "sky130_fd_sc_hd__a21bo_2",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_4 = logic_module(
-    "a21bo_4",
+    "sky130_fd_sc_hd__a21bo_4",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21boi_0 = logic_module(
-    "a21boi_0",
+    "sky130_fd_sc_hd__a21boi_0",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_1 = logic_module(
-    "a21boi_1",
+    "sky130_fd_sc_hd__a21boi_1",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_2 = logic_module(
-    "a21boi_2",
+    "sky130_fd_sc_hd__a21boi_2",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_4 = logic_module(
-    "a21boi_4",
+    "sky130_fd_sc_hd__a21boi_4",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21o_1 = logic_module(
-    "a21o_1",
+    "sky130_fd_sc_hd__a21o_1",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_2 = logic_module(
-    "a21o_2",
+    "sky130_fd_sc_hd__a21o_2",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_4 = logic_module(
-    "a21o_4",
+    "sky130_fd_sc_hd__a21o_4",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21oi_1 = logic_module(
-    "a21oi_1",
+    "sky130_fd_sc_hd__a21oi_1",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_2 = logic_module(
-    "a21oi_2",
+    "sky130_fd_sc_hd__a21oi_2",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_4 = logic_module(
-    "a21oi_4",
+    "sky130_fd_sc_hd__a21oi_4",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22o_1 = logic_module(
-    "a22o_1",
+    "sky130_fd_sc_hd__a22o_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_2 = logic_module(
-    "a22o_2",
+    "sky130_fd_sc_hd__a22o_2",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_4 = logic_module(
-    "a22o_4",
+    "sky130_fd_sc_hd__a22o_4",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22oi_1 = logic_module(
-    "a22oi_1",
+    "sky130_fd_sc_hd__a22oi_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_2 = logic_module(
-    "a22oi_2",
+    "sky130_fd_sc_hd__a22oi_2",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_4 = logic_module(
-    "a22oi_4",
+    "sky130_fd_sc_hd__a22oi_4",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31o_1 = logic_module(
-    "a31o_1",
+    "sky130_fd_sc_hd__a31o_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_2 = logic_module(
-    "a31o_2",
+    "sky130_fd_sc_hd__a31o_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_4 = logic_module(
-    "a31o_4",
+    "sky130_fd_sc_hd__a31o_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31oi_1 = logic_module(
-    "a31oi_1",
+    "sky130_fd_sc_hd__a31oi_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_2 = logic_module(
-    "a31oi_2",
+    "sky130_fd_sc_hd__a31oi_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_4 = logic_module(
-    "a31oi_4",
+    "sky130_fd_sc_hd__a31oi_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32o_1 = logic_module(
-    "a32o_1",
+    "sky130_fd_sc_hd__a32o_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_2 = logic_module(
-    "a32o_2",
+    "sky130_fd_sc_hd__a32o_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_4 = logic_module(
-    "a32o_4",
+    "sky130_fd_sc_hd__a32o_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32oi_1 = logic_module(
-    "a32oi_1",
+    "sky130_fd_sc_hd__a32oi_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_2 = logic_module(
-    "a32oi_2",
+    "sky130_fd_sc_hd__a32oi_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_4 = logic_module(
-    "a32oi_4",
+    "sky130_fd_sc_hd__a32oi_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41o_1 = logic_module(
-    "a41o_1",
+    "sky130_fd_sc_hd__a41o_1",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_2 = logic_module(
-    "a41o_2",
+    "sky130_fd_sc_hd__a41o_2",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_4 = logic_module(
-    "a41o_4",
+    "sky130_fd_sc_hd__a41o_4",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41oi_1 = logic_module(
-    "a41oi_1",
+    "sky130_fd_sc_hd__a41oi_1",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_2 = logic_module(
-    "a41oi_2",
+    "sky130_fd_sc_hd__a41oi_2",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_4 = logic_module(
-    "a41oi_4",
+    "sky130_fd_sc_hd__a41oi_4",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211o_1 = logic_module(
-    "a211o_1",
+    "sky130_fd_sc_hd__a211o_1",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_2 = logic_module(
-    "a211o_2",
+    "sky130_fd_sc_hd__a211o_2",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_4 = logic_module(
-    "a211o_4",
+    "sky130_fd_sc_hd__a211o_4",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211oi_1 = logic_module(
-    "a211oi_1",
+    "sky130_fd_sc_hd__a211oi_1",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_2 = logic_module(
-    "a211oi_2",
+    "sky130_fd_sc_hd__a211oi_2",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_4 = logic_module(
-    "a211oi_4",
+    "sky130_fd_sc_hd__a211oi_4",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221o_1 = logic_module(
-    "a221o_1",
+    "sky130_fd_sc_hd__a221o_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_2 = logic_module(
-    "a221o_2",
+    "sky130_fd_sc_hd__a221o_2",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_4 = logic_module(
-    "a221o_4",
+    "sky130_fd_sc_hd__a221o_4",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221oi_1 = logic_module(
-    "a221oi_1",
+    "sky130_fd_sc_hd__a221oi_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_2 = logic_module(
-    "a221oi_2",
+    "sky130_fd_sc_hd__a221oi_2",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_4 = logic_module(
-    "a221oi_4",
+    "sky130_fd_sc_hd__a221oi_4",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a222oi_1 = logic_module(
-    "a222oi_1",
+    "sky130_fd_sc_hd__a222oi_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311o_1 = logic_module(
-    "a311o_1",
+    "sky130_fd_sc_hd__a311o_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_2 = logic_module(
-    "a311o_2",
+    "sky130_fd_sc_hd__a311o_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_4 = logic_module(
-    "a311o_4",
+    "sky130_fd_sc_hd__a311o_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311oi_1 = logic_module(
-    "a311oi_1",
+    "sky130_fd_sc_hd__a311oi_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_2 = logic_module(
-    "a311oi_2",
+    "sky130_fd_sc_hd__a311oi_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_4 = logic_module(
-    "a311oi_4",
+    "sky130_fd_sc_hd__a311oi_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111o_1 = logic_module(
-    "a2111o_1",
+    "sky130_fd_sc_hd__a2111o_1",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_2 = logic_module(
-    "a2111o_2",
+    "sky130_fd_sc_hd__a2111o_2",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_4 = logic_module(
-    "a2111o_4",
+    "sky130_fd_sc_hd__a2111o_4",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111oi_0 = logic_module(
-    "a2111oi_0",
+    "sky130_fd_sc_hd__a2111oi_0",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_1 = logic_module(
-    "a2111oi_1",
+    "sky130_fd_sc_hd__a2111oi_1",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_2 = logic_module(
-    "a2111oi_2",
+    "sky130_fd_sc_hd__a2111oi_2",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_4 = logic_module(
-    "a2111oi_4",
+    "sky130_fd_sc_hd__a2111oi_4",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 and2_0 = logic_module(
-    "and2_0",
+    "sky130_fd_sc_hd__and2_0",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_1 = logic_module(
-    "and2_1",
+    "sky130_fd_sc_hd__and2_1",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_2 = logic_module(
-    "and2_2",
+    "sky130_fd_sc_hd__and2_2",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_4 = logic_module(
-    "and2_4",
+    "sky130_fd_sc_hd__and2_4",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_1 = logic_module(
-    "and2b_1",
+    "sky130_fd_sc_hd__and2b_1",
     "High Density",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_2 = logic_module(
-    "and2b_2",
+    "sky130_fd_sc_hd__and2b_2",
     "High Density",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_4 = logic_module(
-    "and2b_4",
+    "sky130_fd_sc_hd__and2b_4",
     "High Density",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_1 = logic_module(
-    "and3_1",
+    "sky130_fd_sc_hd__and3_1",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_2 = logic_module(
-    "and3_2",
+    "sky130_fd_sc_hd__and3_2",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_4 = logic_module(
-    "and3_4",
+    "sky130_fd_sc_hd__and3_4",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_1 = logic_module(
-    "and3b_1",
+    "sky130_fd_sc_hd__and3b_1",
     "High Density",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_2 = logic_module(
-    "and3b_2",
+    "sky130_fd_sc_hd__and3b_2",
     "High Density",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_4 = logic_module(
-    "and3b_4",
+    "sky130_fd_sc_hd__and3b_4",
     "High Density",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_1 = logic_module(
-    "and4_1",
+    "sky130_fd_sc_hd__and4_1",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_2 = logic_module(
-    "and4_2",
+    "sky130_fd_sc_hd__and4_2",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_4 = logic_module(
-    "and4_4",
+    "sky130_fd_sc_hd__and4_4",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_1 = logic_module(
-    "and4b_1",
+    "sky130_fd_sc_hd__and4b_1",
     "High Density",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_2 = logic_module(
-    "and4b_2",
+    "sky130_fd_sc_hd__and4b_2",
     "High Density",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_4 = logic_module(
-    "and4b_4",
+    "sky130_fd_sc_hd__and4b_4",
     "High Density",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_1 = logic_module(
-    "and4bb_1",
+    "sky130_fd_sc_hd__and4bb_1",
     "High Density",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_2 = logic_module(
-    "and4bb_2",
+    "sky130_fd_sc_hd__and4bb_2",
     "High Density",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_4 = logic_module(
-    "and4bb_4",
+    "sky130_fd_sc_hd__and4bb_4",
     "High Density",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_1 = logic_module(
-    "buf_1",
+    "sky130_fd_sc_hd__buf_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_2 = logic_module(
-    "buf_2",
+    "sky130_fd_sc_hd__buf_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_4 = logic_module(
-    "buf_4",
+    "sky130_fd_sc_hd__buf_4",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_6 = logic_module(
-    "buf_6",
+    "sky130_fd_sc_hd__buf_6",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_8 = logic_module(
-    "buf_8",
+    "sky130_fd_sc_hd__buf_8",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_12 = logic_module(
-    "buf_12",
+    "sky130_fd_sc_hd__buf_12",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_16 = logic_module(
-    "buf_16",
+    "sky130_fd_sc_hd__buf_16",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_8 = logic_module(
-    "bufbuf_8",
+    "sky130_fd_sc_hd__bufbuf_8",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_16 = logic_module(
-    "bufbuf_16",
+    "sky130_fd_sc_hd__bufbuf_16",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufinv_8 = logic_module(
-    "bufinv_8",
+    "sky130_fd_sc_hd__bufinv_8",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 bufinv_16 = logic_module(
-    "bufinv_16",
+    "sky130_fd_sc_hd__bufinv_16",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkbuf_1 = logic_module(
-    "clkbuf_1",
+    "sky130_fd_sc_hd__clkbuf_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_2 = logic_module(
-    "clkbuf_2",
+    "sky130_fd_sc_hd__clkbuf_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_4 = logic_module(
-    "clkbuf_4",
+    "sky130_fd_sc_hd__clkbuf_4",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_8 = logic_module(
-    "clkbuf_8",
+    "sky130_fd_sc_hd__clkbuf_8",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_16 = logic_module(
-    "clkbuf_16",
+    "sky130_fd_sc_hd__clkbuf_16",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s15_1 = logic_module(
-    "clkdlybuf4s15_1",
+    "sky130_fd_sc_hd__clkdlybuf4s15_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s15_2 = logic_module(
-    "clkdlybuf4s15_2",
+    "sky130_fd_sc_hd__clkdlybuf4s15_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s18_1 = logic_module(
-    "clkdlybuf4s18_1",
+    "sky130_fd_sc_hd__clkdlybuf4s18_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s18_2 = logic_module(
-    "clkdlybuf4s18_2",
+    "sky130_fd_sc_hd__clkdlybuf4s18_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s25_1 = logic_module(
-    "clkdlybuf4s25_1",
+    "sky130_fd_sc_hd__clkdlybuf4s25_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s25_2 = logic_module(
-    "clkdlybuf4s25_2",
+    "sky130_fd_sc_hd__clkdlybuf4s25_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s50_1 = logic_module(
-    "clkdlybuf4s50_1",
+    "sky130_fd_sc_hd__clkdlybuf4s50_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s50_2 = logic_module(
-    "clkdlybuf4s50_2",
+    "sky130_fd_sc_hd__clkdlybuf4s50_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkinv_1 = logic_module(
-    "clkinv_1",
+    "sky130_fd_sc_hd__clkinv_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_2 = logic_module(
-    "clkinv_2",
+    "sky130_fd_sc_hd__clkinv_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_4 = logic_module(
-    "clkinv_4",
+    "sky130_fd_sc_hd__clkinv_4",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_8 = logic_module(
-    "clkinv_8",
+    "sky130_fd_sc_hd__clkinv_8",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_16 = logic_module(
-    "clkinv_16",
+    "sky130_fd_sc_hd__clkinv_16",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinvlp_2 = logic_module(
-    "clkinvlp_2",
+    "sky130_fd_sc_hd__clkinvlp_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinvlp_4 = logic_module(
-    "clkinvlp_4",
+    "sky130_fd_sc_hd__clkinvlp_4",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 conb_1 = logic_module(
-    "conb_1",
+    "sky130_fd_sc_hd__conb_1",
     "High Density",
     ["VGND", "VNB", "VPB", "VPWR", "HI", "LO"],
 )
-decap_3 = logic_module("decap_3", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-decap_4 = logic_module("decap_4", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-decap_6 = logic_module("decap_6", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-decap_8 = logic_module("decap_8", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-decap_12 = logic_module("decap_12", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
+decap_3 = logic_module(
+    "sky130_fd_sc_hd__decap_3", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_4 = logic_module(
+    "sky130_fd_sc_hd__decap_4", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_6 = logic_module(
+    "sky130_fd_sc_hd__decap_6", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_8 = logic_module(
+    "sky130_fd_sc_hd__decap_8", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_12 = logic_module(
+    "sky130_fd_sc_hd__decap_12", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
 dfbbn_1 = logic_module(
-    "dfbbn_1",
+    "sky130_fd_sc_hd__dfbbn_1",
     "High Density",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbn_2 = logic_module(
-    "dfbbn_2",
+    "sky130_fd_sc_hd__dfbbn_2",
     "High Density",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbp_1 = logic_module(
-    "dfbbp_1",
+    "sky130_fd_sc_hd__dfbbp_1",
     "High Density",
     ["CLK", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_1 = logic_module(
-    "dfrbp_1",
+    "sky130_fd_sc_hd__dfrbp_1",
     "High Density",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_2 = logic_module(
-    "dfrbp_2",
+    "sky130_fd_sc_hd__dfrbp_2",
     "High Density",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrtn_1 = logic_module(
-    "dfrtn_1",
+    "sky130_fd_sc_hd__dfrtn_1",
     "High Density",
     ["CLK_N", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_1 = logic_module(
-    "dfrtp_1",
+    "sky130_fd_sc_hd__dfrtp_1",
     "High Density",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_2 = logic_module(
-    "dfrtp_2",
+    "sky130_fd_sc_hd__dfrtp_2",
     "High Density",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_4 = logic_module(
-    "dfrtp_4",
+    "sky130_fd_sc_hd__dfrtp_4",
     "High Density",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfsbp_1 = logic_module(
-    "dfsbp_1",
+    "sky130_fd_sc_hd__dfsbp_1",
     "High Density",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfsbp_2 = logic_module(
-    "dfsbp_2",
+    "sky130_fd_sc_hd__dfsbp_2",
     "High Density",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfstp_1 = logic_module(
-    "dfstp_1",
+    "sky130_fd_sc_hd__dfstp_1",
     "High Density",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_2 = logic_module(
-    "dfstp_2",
+    "sky130_fd_sc_hd__dfstp_2",
     "High Density",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_4 = logic_module(
-    "dfstp_4",
+    "sky130_fd_sc_hd__dfstp_4",
     "High Density",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxbp_1 = logic_module(
-    "dfxbp_1",
+    "sky130_fd_sc_hd__dfxbp_1",
     "High Density",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxbp_2 = logic_module(
-    "dfxbp_2",
+    "sky130_fd_sc_hd__dfxbp_2",
     "High Density",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxtp_1 = logic_module(
-    "dfxtp_1",
+    "sky130_fd_sc_hd__dfxtp_1",
     "High Density",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_2 = logic_module(
-    "dfxtp_2",
+    "sky130_fd_sc_hd__dfxtp_2",
     "High Density",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_4 = logic_module(
-    "dfxtp_4",
+    "sky130_fd_sc_hd__dfxtp_4",
     "High Density",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 diode_2 = logic_module(
-    "diode_2",
+    "sky130_fd_sc_hd__diode_2",
     "High Density",
     ["DIODE", "VGND", "VNB", "VPB", "VPWR"],
 )
 dlclkp_1 = logic_module(
-    "dlclkp_1",
+    "sky130_fd_sc_hd__dlclkp_1",
     "High Density",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_2 = logic_module(
-    "dlclkp_2",
+    "sky130_fd_sc_hd__dlclkp_2",
     "High Density",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_4 = logic_module(
-    "dlclkp_4",
+    "sky130_fd_sc_hd__dlclkp_4",
     "High Density",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlrbn_1 = logic_module(
-    "dlrbn_1",
+    "sky130_fd_sc_hd__dlrbn_1",
     "High Density",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbn_2 = logic_module(
-    "dlrbn_2",
+    "sky130_fd_sc_hd__dlrbn_2",
     "High Density",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_1 = logic_module(
-    "dlrbp_1",
+    "sky130_fd_sc_hd__dlrbp_1",
     "High Density",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_2 = logic_module(
-    "dlrbp_2",
+    "sky130_fd_sc_hd__dlrbp_2",
     "High Density",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrtn_1 = logic_module(
-    "dlrtn_1",
+    "sky130_fd_sc_hd__dlrtn_1",
     "High Density",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_2 = logic_module(
-    "dlrtn_2",
+    "sky130_fd_sc_hd__dlrtn_2",
     "High Density",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_4 = logic_module(
-    "dlrtn_4",
+    "sky130_fd_sc_hd__dlrtn_4",
     "High Density",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_1 = logic_module(
-    "dlrtp_1",
+    "sky130_fd_sc_hd__dlrtp_1",
     "High Density",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_2 = logic_module(
-    "dlrtp_2",
+    "sky130_fd_sc_hd__dlrtp_2",
     "High Density",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_4 = logic_module(
-    "dlrtp_4",
+    "sky130_fd_sc_hd__dlrtp_4",
     "High Density",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxbn_1 = logic_module(
-    "dlxbn_1",
+    "sky130_fd_sc_hd__dlxbn_1",
     "High Density",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbn_2 = logic_module(
-    "dlxbn_2",
+    "sky130_fd_sc_hd__dlxbn_2",
     "High Density",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbp_1 = logic_module(
-    "dlxbp_1",
+    "sky130_fd_sc_hd__dlxbp_1",
     "High Density",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxtn_1 = logic_module(
-    "dlxtn_1",
+    "sky130_fd_sc_hd__dlxtn_1",
     "High Density",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_2 = logic_module(
-    "dlxtn_2",
+    "sky130_fd_sc_hd__dlxtn_2",
     "High Density",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_4 = logic_module(
-    "dlxtn_4",
+    "sky130_fd_sc_hd__dlxtn_4",
     "High Density",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtp_1 = logic_module(
-    "dlxtp_1",
+    "sky130_fd_sc_hd__dlxtp_1",
     "High Density",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlygate4sd1_1 = logic_module(
-    "dlygate4sd1_1",
+    "sky130_fd_sc_hd__dlygate4sd1_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd2_1 = logic_module(
-    "dlygate4sd2_1",
+    "sky130_fd_sc_hd__dlygate4sd2_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd3_1 = logic_module(
-    "dlygate4sd3_1",
+    "sky130_fd_sc_hd__dlygate4sd3_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s2s_1 = logic_module(
-    "dlymetal6s2s_1",
+    "sky130_fd_sc_hd__dlymetal6s2s_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s4s_1 = logic_module(
-    "dlymetal6s4s_1",
+    "sky130_fd_sc_hd__dlymetal6s4s_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s6s_1 = logic_module(
-    "dlymetal6s6s_1",
+    "sky130_fd_sc_hd__dlymetal6s6s_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 ebufn_1 = logic_module(
-    "ebufn_1",
+    "sky130_fd_sc_hd__ebufn_1",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_2 = logic_module(
-    "ebufn_2",
+    "sky130_fd_sc_hd__ebufn_2",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_4 = logic_module(
-    "ebufn_4",
+    "sky130_fd_sc_hd__ebufn_4",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_8 = logic_module(
-    "ebufn_8",
+    "sky130_fd_sc_hd__ebufn_8",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 edfxbp_1 = logic_module(
-    "edfxbp_1",
+    "sky130_fd_sc_hd__edfxbp_1",
     "High Density",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 edfxtp_1 = logic_module(
-    "edfxtp_1",
+    "sky130_fd_sc_hd__edfxtp_1",
     "High Density",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 einvn_0 = logic_module(
-    "einvn_0",
+    "sky130_fd_sc_hd__einvn_0",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_1 = logic_module(
-    "einvn_1",
+    "sky130_fd_sc_hd__einvn_1",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_2 = logic_module(
-    "einvn_2",
+    "sky130_fd_sc_hd__einvn_2",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_4 = logic_module(
-    "einvn_4",
+    "sky130_fd_sc_hd__einvn_4",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_8 = logic_module(
-    "einvn_8",
+    "sky130_fd_sc_hd__einvn_8",
     "High Density",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_1 = logic_module(
-    "einvp_1",
+    "sky130_fd_sc_hd__einvp_1",
     "High Density",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_2 = logic_module(
-    "einvp_2",
+    "sky130_fd_sc_hd__einvp_2",
     "High Density",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_4 = logic_module(
-    "einvp_4",
+    "sky130_fd_sc_hd__einvp_4",
     "High Density",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_8 = logic_module(
-    "einvp_8",
+    "sky130_fd_sc_hd__einvp_8",
     "High Density",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 fa_1 = logic_module(
-    "fa_1",
+    "sky130_fd_sc_hd__fa_1",
     "High Density",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_2 = logic_module(
-    "fa_2",
+    "sky130_fd_sc_hd__fa_2",
     "High Density",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_4 = logic_module(
-    "fa_4",
+    "sky130_fd_sc_hd__fa_4",
     "High Density",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_1 = logic_module(
-    "fah_1",
+    "sky130_fd_sc_hd__fah_1",
     "High Density",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcin_1 = logic_module(
-    "fahcin_1",
+    "sky130_fd_sc_hd__fahcin_1",
     "High Density",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcon_1 = logic_module(
-    "fahcon_1",
+    "sky130_fd_sc_hd__fahcon_1",
     "High Density",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT_N", "SUM"],
 )
-fill_1 = logic_module("fill_1", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-fill_2 = logic_module("fill_2", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-fill_4 = logic_module("fill_4", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-fill_8 = logic_module("fill_8", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
+fill_1 = logic_module(
+    "sky130_fd_sc_hd__fill_1", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_2 = logic_module(
+    "sky130_fd_sc_hd__fill_2", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_4 = logic_module(
+    "sky130_fd_sc_hd__fill_4", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_8 = logic_module(
+    "sky130_fd_sc_hd__fill_8", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
 ha_1 = logic_module(
-    "ha_1",
+    "sky130_fd_sc_hd__ha_1",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_2 = logic_module(
-    "ha_2",
+    "sky130_fd_sc_hd__ha_2",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_4 = logic_module(
-    "ha_4",
+    "sky130_fd_sc_hd__ha_4",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 inv_1 = logic_module(
-    "inv_1",
+    "sky130_fd_sc_hd__inv_1",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_2 = logic_module(
-    "inv_2",
+    "sky130_fd_sc_hd__inv_2",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_4 = logic_module(
-    "inv_4",
+    "sky130_fd_sc_hd__inv_4",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_6 = logic_module(
-    "inv_6",
+    "sky130_fd_sc_hd__inv_6",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_8 = logic_module(
-    "inv_8",
+    "sky130_fd_sc_hd__inv_8",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_12 = logic_module(
-    "inv_12",
+    "sky130_fd_sc_hd__inv_12",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_16 = logic_module(
-    "inv_16",
+    "sky130_fd_sc_hd__inv_16",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 lpflow_bleeder_1 = logic_module(
-    "lpflow_bleeder_1",
+    "sky130_fd_sc_hd__lpflow_bleeder_1",
     "High Density",
     ["SHORT", "VGND", "VNB", "VPB", "VPWR"],
 )
 lpflow_clkbufkapwr_1 = logic_module(
-    "lpflow_clkbufkapwr_1",
+    "sky130_fd_sc_hd__lpflow_clkbufkapwr_1",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_clkbufkapwr_2 = logic_module(
-    "lpflow_clkbufkapwr_2",
+    "sky130_fd_sc_hd__lpflow_clkbufkapwr_2",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_clkbufkapwr_4 = logic_module(
-    "lpflow_clkbufkapwr_4",
+    "sky130_fd_sc_hd__lpflow_clkbufkapwr_4",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_clkbufkapwr_8 = logic_module(
-    "lpflow_clkbufkapwr_8",
+    "sky130_fd_sc_hd__lpflow_clkbufkapwr_8",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_clkbufkapwr_16 = logic_module(
-    "lpflow_clkbufkapwr_16",
+    "sky130_fd_sc_hd__lpflow_clkbufkapwr_16",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_clkinvkapwr_1 = logic_module(
-    "lpflow_clkinvkapwr_1",
+    "sky130_fd_sc_hd__lpflow_clkinvkapwr_1",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 lpflow_clkinvkapwr_2 = logic_module(
-    "lpflow_clkinvkapwr_2",
+    "sky130_fd_sc_hd__lpflow_clkinvkapwr_2",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 lpflow_clkinvkapwr_4 = logic_module(
-    "lpflow_clkinvkapwr_4",
+    "sky130_fd_sc_hd__lpflow_clkinvkapwr_4",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 lpflow_clkinvkapwr_8 = logic_module(
-    "lpflow_clkinvkapwr_8",
+    "sky130_fd_sc_hd__lpflow_clkinvkapwr_8",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 lpflow_clkinvkapwr_16 = logic_module(
-    "lpflow_clkinvkapwr_16",
+    "sky130_fd_sc_hd__lpflow_clkinvkapwr_16",
     "High Density",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 lpflow_decapkapwr_3 = logic_module(
-    "lpflow_decapkapwr_3",
+    "sky130_fd_sc_hd__lpflow_decapkapwr_3",
     "High Density",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 lpflow_decapkapwr_4 = logic_module(
-    "lpflow_decapkapwr_4",
+    "sky130_fd_sc_hd__lpflow_decapkapwr_4",
     "High Density",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 lpflow_decapkapwr_6 = logic_module(
-    "lpflow_decapkapwr_6",
+    "sky130_fd_sc_hd__lpflow_decapkapwr_6",
     "High Density",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 lpflow_decapkapwr_8 = logic_module(
-    "lpflow_decapkapwr_8",
+    "sky130_fd_sc_hd__lpflow_decapkapwr_8",
     "High Density",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 lpflow_decapkapwr_12 = logic_module(
-    "lpflow_decapkapwr_12",
+    "sky130_fd_sc_hd__lpflow_decapkapwr_12",
     "High Density",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 lpflow_inputiso0n_1 = logic_module(
-    "lpflow_inputiso0n_1",
+    "sky130_fd_sc_hd__lpflow_inputiso0n_1",
     "High Density",
     ["A", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_inputiso0p_1 = logic_module(
-    "lpflow_inputiso0p_1",
+    "sky130_fd_sc_hd__lpflow_inputiso0p_1",
     "High Density",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_inputiso1n_1 = logic_module(
-    "lpflow_inputiso1n_1",
+    "sky130_fd_sc_hd__lpflow_inputiso1n_1",
     "High Density",
     ["A", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_inputiso1p_1 = logic_module(
-    "lpflow_inputiso1p_1",
+    "sky130_fd_sc_hd__lpflow_inputiso1p_1",
     "High Density",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_inputisolatch_1 = logic_module(
-    "lpflow_inputisolatch_1",
+    "sky130_fd_sc_hd__lpflow_inputisolatch_1",
     "High Density",
     ["D", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 lpflow_isobufsrc_1 = logic_module(
-    "lpflow_isobufsrc_1",
+    "sky130_fd_sc_hd__lpflow_isobufsrc_1",
     "High Density",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_isobufsrc_2 = logic_module(
-    "lpflow_isobufsrc_2",
+    "sky130_fd_sc_hd__lpflow_isobufsrc_2",
     "High Density",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_isobufsrc_4 = logic_module(
-    "lpflow_isobufsrc_4",
+    "sky130_fd_sc_hd__lpflow_isobufsrc_4",
     "High Density",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_isobufsrc_8 = logic_module(
-    "lpflow_isobufsrc_8",
+    "sky130_fd_sc_hd__lpflow_isobufsrc_8",
     "High Density",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_isobufsrc_16 = logic_module(
-    "lpflow_isobufsrc_16",
+    "sky130_fd_sc_hd__lpflow_isobufsrc_16",
     "High Density",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_isobufsrckapwr_16 = logic_module(
-    "lpflow_isobufsrckapwr_16",
+    "sky130_fd_sc_hd__lpflow_isobufsrckapwr_16",
     "High Density",
     ["A", "SLEEP", "KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 lpflow_lsbuf_lh_hl_isowell_tap_1 = logic_module(
-    "lpflow_lsbuf_lh_hl_isowell_tap_1",
+    "sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_1",
     "High Density",
     ["A", "VGND", "VPB", "VPWRIN", "VPWR", "X"],
 )
 lpflow_lsbuf_lh_hl_isowell_tap_2 = logic_module(
-    "lpflow_lsbuf_lh_hl_isowell_tap_2",
+    "sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_2",
     "High Density",
     ["A", "VGND", "VPB", "VPWRIN", "VPWR", "X"],
 )
 lpflow_lsbuf_lh_hl_isowell_tap_4 = logic_module(
-    "lpflow_lsbuf_lh_hl_isowell_tap_4",
+    "sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_4",
     "High Density",
     ["A", "VGND", "VPB", "VPWRIN", "VPWR", "X"],
 )
 lpflow_lsbuf_lh_isowell_4 = logic_module(
-    "lpflow_lsbuf_lh_isowell_4",
+    "sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_4",
     "High Density",
     ["A", "LOWLVPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 lpflow_lsbuf_lh_isowell_tap_1 = logic_module(
-    "lpflow_lsbuf_lh_isowell_tap_1",
+    "sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_1",
     "High Density",
     ["A", "LOWLVPWR", "VGND", "VPB", "VPWR", "X"],
 )
 lpflow_lsbuf_lh_isowell_tap_2 = logic_module(
-    "lpflow_lsbuf_lh_isowell_tap_2",
+    "sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_2",
     "High Density",
     ["A", "LOWLVPWR", "VGND", "VPB", "VPWR", "X"],
 )
 lpflow_lsbuf_lh_isowell_tap_4 = logic_module(
-    "lpflow_lsbuf_lh_isowell_tap_4",
+    "sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_4",
     "High Density",
     ["A", "LOWLVPWR", "VGND", "VPB", "VPWR", "X"],
 )
 macro_sparecell = logic_module(
-    "macro_sparecell",
+    "sky130_fd_sc_hd__macro_sparecell",
     "High Density",
     ["VGND", "VNB", "VPB", "VPWR", "LO"],
 )
 maj3_1 = logic_module(
-    "maj3_1",
+    "sky130_fd_sc_hd__maj3_1",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_2 = logic_module(
-    "maj3_2",
+    "sky130_fd_sc_hd__maj3_2",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_4 = logic_module(
-    "maj3_4",
+    "sky130_fd_sc_hd__maj3_4",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_1 = logic_module(
-    "mux2_1",
+    "sky130_fd_sc_hd__mux2_1",
     "High Density",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_2 = logic_module(
-    "mux2_2",
+    "sky130_fd_sc_hd__mux2_2",
     "High Density",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_4 = logic_module(
-    "mux2_4",
+    "sky130_fd_sc_hd__mux2_4",
     "High Density",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_8 = logic_module(
-    "mux2_8",
+    "sky130_fd_sc_hd__mux2_8",
     "High Density",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2i_1 = logic_module(
-    "mux2i_1",
+    "sky130_fd_sc_hd__mux2i_1",
     "High Density",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_2 = logic_module(
-    "mux2i_2",
+    "sky130_fd_sc_hd__mux2i_2",
     "High Density",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_4 = logic_module(
-    "mux2i_4",
+    "sky130_fd_sc_hd__mux2i_4",
     "High Density",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux4_1 = logic_module(
-    "mux4_1",
+    "sky130_fd_sc_hd__mux4_1",
     "High Density",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_2 = logic_module(
-    "mux4_2",
+    "sky130_fd_sc_hd__mux4_2",
     "High Density",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_4 = logic_module(
-    "mux4_4",
+    "sky130_fd_sc_hd__mux4_4",
     "High Density",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 nand2_1 = logic_module(
-    "nand2_1",
+    "sky130_fd_sc_hd__nand2_1",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_2 = logic_module(
-    "nand2_2",
+    "sky130_fd_sc_hd__nand2_2",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_4 = logic_module(
-    "nand2_4",
+    "sky130_fd_sc_hd__nand2_4",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_8 = logic_module(
-    "nand2_8",
+    "sky130_fd_sc_hd__nand2_8",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_1 = logic_module(
-    "nand2b_1",
+    "sky130_fd_sc_hd__nand2b_1",
     "High Density",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_2 = logic_module(
-    "nand2b_2",
+    "sky130_fd_sc_hd__nand2b_2",
     "High Density",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_4 = logic_module(
-    "nand2b_4",
+    "sky130_fd_sc_hd__nand2b_4",
     "High Density",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_1 = logic_module(
-    "nand3_1",
+    "sky130_fd_sc_hd__nand3_1",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_2 = logic_module(
-    "nand3_2",
+    "sky130_fd_sc_hd__nand3_2",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_4 = logic_module(
-    "nand3_4",
+    "sky130_fd_sc_hd__nand3_4",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_1 = logic_module(
-    "nand3b_1",
+    "sky130_fd_sc_hd__nand3b_1",
     "High Density",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_2 = logic_module(
-    "nand3b_2",
+    "sky130_fd_sc_hd__nand3b_2",
     "High Density",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_4 = logic_module(
-    "nand3b_4",
+    "sky130_fd_sc_hd__nand3b_4",
     "High Density",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_1 = logic_module(
-    "nand4_1",
+    "sky130_fd_sc_hd__nand4_1",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_2 = logic_module(
-    "nand4_2",
+    "sky130_fd_sc_hd__nand4_2",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_4 = logic_module(
-    "nand4_4",
+    "sky130_fd_sc_hd__nand4_4",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_1 = logic_module(
-    "nand4b_1",
+    "sky130_fd_sc_hd__nand4b_1",
     "High Density",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_2 = logic_module(
-    "nand4b_2",
+    "sky130_fd_sc_hd__nand4b_2",
     "High Density",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_4 = logic_module(
-    "nand4b_4",
+    "sky130_fd_sc_hd__nand4b_4",
     "High Density",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_1 = logic_module(
-    "nand4bb_1",
+    "sky130_fd_sc_hd__nand4bb_1",
     "High Density",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_2 = logic_module(
-    "nand4bb_2",
+    "sky130_fd_sc_hd__nand4bb_2",
     "High Density",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_4 = logic_module(
-    "nand4bb_4",
+    "sky130_fd_sc_hd__nand4bb_4",
     "High Density",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_1 = logic_module(
-    "nor2_1",
+    "sky130_fd_sc_hd__nor2_1",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_2 = logic_module(
-    "nor2_2",
+    "sky130_fd_sc_hd__nor2_2",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_4 = logic_module(
-    "nor2_4",
+    "sky130_fd_sc_hd__nor2_4",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_8 = logic_module(
-    "nor2_8",
+    "sky130_fd_sc_hd__nor2_8",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_1 = logic_module(
-    "nor2b_1",
+    "sky130_fd_sc_hd__nor2b_1",
     "High Density",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_2 = logic_module(
-    "nor2b_2",
+    "sky130_fd_sc_hd__nor2b_2",
     "High Density",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_4 = logic_module(
-    "nor2b_4",
+    "sky130_fd_sc_hd__nor2b_4",
     "High Density",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_1 = logic_module(
-    "nor3_1",
+    "sky130_fd_sc_hd__nor3_1",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_2 = logic_module(
-    "nor3_2",
+    "sky130_fd_sc_hd__nor3_2",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_4 = logic_module(
-    "nor3_4",
+    "sky130_fd_sc_hd__nor3_4",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_1 = logic_module(
-    "nor3b_1",
+    "sky130_fd_sc_hd__nor3b_1",
     "High Density",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_2 = logic_module(
-    "nor3b_2",
+    "sky130_fd_sc_hd__nor3b_2",
     "High Density",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_4 = logic_module(
-    "nor3b_4",
+    "sky130_fd_sc_hd__nor3b_4",
     "High Density",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_1 = logic_module(
-    "nor4_1",
+    "sky130_fd_sc_hd__nor4_1",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_2 = logic_module(
-    "nor4_2",
+    "sky130_fd_sc_hd__nor4_2",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_4 = logic_module(
-    "nor4_4",
+    "sky130_fd_sc_hd__nor4_4",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_1 = logic_module(
-    "nor4b_1",
+    "sky130_fd_sc_hd__nor4b_1",
     "High Density",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_2 = logic_module(
-    "nor4b_2",
+    "sky130_fd_sc_hd__nor4b_2",
     "High Density",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_4 = logic_module(
-    "nor4b_4",
+    "sky130_fd_sc_hd__nor4b_4",
     "High Density",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_1 = logic_module(
-    "nor4bb_1",
+    "sky130_fd_sc_hd__nor4bb_1",
     "High Density",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_2 = logic_module(
-    "nor4bb_2",
+    "sky130_fd_sc_hd__nor4bb_2",
     "High Density",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_4 = logic_module(
-    "nor4bb_4",
+    "sky130_fd_sc_hd__nor4bb_4",
     "High Density",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2a_1 = logic_module(
-    "o2bb2a_1",
+    "sky130_fd_sc_hd__o2bb2a_1",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_2 = logic_module(
-    "o2bb2a_2",
+    "sky130_fd_sc_hd__o2bb2a_2",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_4 = logic_module(
-    "o2bb2a_4",
+    "sky130_fd_sc_hd__o2bb2a_4",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2ai_1 = logic_module(
-    "o2bb2ai_1",
+    "sky130_fd_sc_hd__o2bb2ai_1",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_2 = logic_module(
-    "o2bb2ai_2",
+    "sky130_fd_sc_hd__o2bb2ai_2",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_4 = logic_module(
-    "o2bb2ai_4",
+    "sky130_fd_sc_hd__o2bb2ai_4",
     "High Density",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21a_1 = logic_module(
-    "o21a_1",
+    "sky130_fd_sc_hd__o21a_1",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_2 = logic_module(
-    "o21a_2",
+    "sky130_fd_sc_hd__o21a_2",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_4 = logic_module(
-    "o21a_4",
+    "sky130_fd_sc_hd__o21a_4",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ai_0 = logic_module(
-    "o21ai_0",
+    "sky130_fd_sc_hd__o21ai_0",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_1 = logic_module(
-    "o21ai_1",
+    "sky130_fd_sc_hd__o21ai_1",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_2 = logic_module(
-    "o21ai_2",
+    "sky130_fd_sc_hd__o21ai_2",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_4 = logic_module(
-    "o21ai_4",
+    "sky130_fd_sc_hd__o21ai_4",
     "High Density",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ba_1 = logic_module(
-    "o21ba_1",
+    "sky130_fd_sc_hd__o21ba_1",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_2 = logic_module(
-    "o21ba_2",
+    "sky130_fd_sc_hd__o21ba_2",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_4 = logic_module(
-    "o21ba_4",
+    "sky130_fd_sc_hd__o21ba_4",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21bai_1 = logic_module(
-    "o21bai_1",
+    "sky130_fd_sc_hd__o21bai_1",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_2 = logic_module(
-    "o21bai_2",
+    "sky130_fd_sc_hd__o21bai_2",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_4 = logic_module(
-    "o21bai_4",
+    "sky130_fd_sc_hd__o21bai_4",
     "High Density",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22a_1 = logic_module(
-    "o22a_1",
+    "sky130_fd_sc_hd__o22a_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_2 = logic_module(
-    "o22a_2",
+    "sky130_fd_sc_hd__o22a_2",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_4 = logic_module(
-    "o22a_4",
+    "sky130_fd_sc_hd__o22a_4",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22ai_1 = logic_module(
-    "o22ai_1",
+    "sky130_fd_sc_hd__o22ai_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_2 = logic_module(
-    "o22ai_2",
+    "sky130_fd_sc_hd__o22ai_2",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_4 = logic_module(
-    "o22ai_4",
+    "sky130_fd_sc_hd__o22ai_4",
     "High Density",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31a_1 = logic_module(
-    "o31a_1",
+    "sky130_fd_sc_hd__o31a_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_2 = logic_module(
-    "o31a_2",
+    "sky130_fd_sc_hd__o31a_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_4 = logic_module(
-    "o31a_4",
+    "sky130_fd_sc_hd__o31a_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31ai_1 = logic_module(
-    "o31ai_1",
+    "sky130_fd_sc_hd__o31ai_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_2 = logic_module(
-    "o31ai_2",
+    "sky130_fd_sc_hd__o31ai_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_4 = logic_module(
-    "o31ai_4",
+    "sky130_fd_sc_hd__o31ai_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32a_1 = logic_module(
-    "o32a_1",
+    "sky130_fd_sc_hd__o32a_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_2 = logic_module(
-    "o32a_2",
+    "sky130_fd_sc_hd__o32a_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_4 = logic_module(
-    "o32a_4",
+    "sky130_fd_sc_hd__o32a_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32ai_1 = logic_module(
-    "o32ai_1",
+    "sky130_fd_sc_hd__o32ai_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_2 = logic_module(
-    "o32ai_2",
+    "sky130_fd_sc_hd__o32ai_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_4 = logic_module(
-    "o32ai_4",
+    "sky130_fd_sc_hd__o32ai_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41a_1 = logic_module(
-    "o41a_1",
+    "sky130_fd_sc_hd__o41a_1",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_2 = logic_module(
-    "o41a_2",
+    "sky130_fd_sc_hd__o41a_2",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_4 = logic_module(
-    "o41a_4",
+    "sky130_fd_sc_hd__o41a_4",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41ai_1 = logic_module(
-    "o41ai_1",
+    "sky130_fd_sc_hd__o41ai_1",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_2 = logic_module(
-    "o41ai_2",
+    "sky130_fd_sc_hd__o41ai_2",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_4 = logic_module(
-    "o41ai_4",
+    "sky130_fd_sc_hd__o41ai_4",
     "High Density",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211a_1 = logic_module(
-    "o211a_1",
+    "sky130_fd_sc_hd__o211a_1",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_2 = logic_module(
-    "o211a_2",
+    "sky130_fd_sc_hd__o211a_2",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_4 = logic_module(
-    "o211a_4",
+    "sky130_fd_sc_hd__o211a_4",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211ai_1 = logic_module(
-    "o211ai_1",
+    "sky130_fd_sc_hd__o211ai_1",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_2 = logic_module(
-    "o211ai_2",
+    "sky130_fd_sc_hd__o211ai_2",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_4 = logic_module(
-    "o211ai_4",
+    "sky130_fd_sc_hd__o211ai_4",
     "High Density",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221a_1 = logic_module(
-    "o221a_1",
+    "sky130_fd_sc_hd__o221a_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_2 = logic_module(
-    "o221a_2",
+    "sky130_fd_sc_hd__o221a_2",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_4 = logic_module(
-    "o221a_4",
+    "sky130_fd_sc_hd__o221a_4",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221ai_1 = logic_module(
-    "o221ai_1",
+    "sky130_fd_sc_hd__o221ai_1",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_2 = logic_module(
-    "o221ai_2",
+    "sky130_fd_sc_hd__o221ai_2",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_4 = logic_module(
-    "o221ai_4",
+    "sky130_fd_sc_hd__o221ai_4",
     "High Density",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311a_1 = logic_module(
-    "o311a_1",
+    "sky130_fd_sc_hd__o311a_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_2 = logic_module(
-    "o311a_2",
+    "sky130_fd_sc_hd__o311a_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_4 = logic_module(
-    "o311a_4",
+    "sky130_fd_sc_hd__o311a_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311ai_0 = logic_module(
-    "o311ai_0",
+    "sky130_fd_sc_hd__o311ai_0",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_1 = logic_module(
-    "o311ai_1",
+    "sky130_fd_sc_hd__o311ai_1",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_2 = logic_module(
-    "o311ai_2",
+    "sky130_fd_sc_hd__o311ai_2",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_4 = logic_module(
-    "o311ai_4",
+    "sky130_fd_sc_hd__o311ai_4",
     "High Density",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111a_1 = logic_module(
-    "o2111a_1",
+    "sky130_fd_sc_hd__o2111a_1",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_2 = logic_module(
-    "o2111a_2",
+    "sky130_fd_sc_hd__o2111a_2",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_4 = logic_module(
-    "o2111a_4",
+    "sky130_fd_sc_hd__o2111a_4",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111ai_1 = logic_module(
-    "o2111ai_1",
+    "sky130_fd_sc_hd__o2111ai_1",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_2 = logic_module(
-    "o2111ai_2",
+    "sky130_fd_sc_hd__o2111ai_2",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_4 = logic_module(
-    "o2111ai_4",
+    "sky130_fd_sc_hd__o2111ai_4",
     "High Density",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 or2_0 = logic_module(
-    "or2_0",
+    "sky130_fd_sc_hd__or2_0",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_1 = logic_module(
-    "or2_1",
+    "sky130_fd_sc_hd__or2_1",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_2 = logic_module(
-    "or2_2",
+    "sky130_fd_sc_hd__or2_2",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_4 = logic_module(
-    "or2_4",
+    "sky130_fd_sc_hd__or2_4",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_1 = logic_module(
-    "or2b_1",
+    "sky130_fd_sc_hd__or2b_1",
     "High Density",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_2 = logic_module(
-    "or2b_2",
+    "sky130_fd_sc_hd__or2b_2",
     "High Density",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_4 = logic_module(
-    "or2b_4",
+    "sky130_fd_sc_hd__or2b_4",
     "High Density",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_1 = logic_module(
-    "or3_1",
+    "sky130_fd_sc_hd__or3_1",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_2 = logic_module(
-    "or3_2",
+    "sky130_fd_sc_hd__or3_2",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_4 = logic_module(
-    "or3_4",
+    "sky130_fd_sc_hd__or3_4",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_1 = logic_module(
-    "or3b_1",
+    "sky130_fd_sc_hd__or3b_1",
     "High Density",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_2 = logic_module(
-    "or3b_2",
+    "sky130_fd_sc_hd__or3b_2",
     "High Density",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_4 = logic_module(
-    "or3b_4",
+    "sky130_fd_sc_hd__or3b_4",
     "High Density",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_1 = logic_module(
-    "or4_1",
+    "sky130_fd_sc_hd__or4_1",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_2 = logic_module(
-    "or4_2",
+    "sky130_fd_sc_hd__or4_2",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_4 = logic_module(
-    "or4_4",
+    "sky130_fd_sc_hd__or4_4",
     "High Density",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_1 = logic_module(
-    "or4b_1",
+    "sky130_fd_sc_hd__or4b_1",
     "High Density",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_2 = logic_module(
-    "or4b_2",
+    "sky130_fd_sc_hd__or4b_2",
     "High Density",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_4 = logic_module(
-    "or4b_4",
+    "sky130_fd_sc_hd__or4b_4",
     "High Density",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_1 = logic_module(
-    "or4bb_1",
+    "sky130_fd_sc_hd__or4bb_1",
     "High Density",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_2 = logic_module(
-    "or4bb_2",
+    "sky130_fd_sc_hd__or4bb_2",
     "High Density",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_4 = logic_module(
-    "or4bb_4",
+    "sky130_fd_sc_hd__or4bb_4",
     "High Density",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 probe_p_8 = logic_module(
-    "probe_p_8",
+    "sky130_fd_sc_hd__probe_p_8",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 probec_p_8 = logic_module(
-    "probec_p_8",
+    "sky130_fd_sc_hd__probec_p_8",
     "High Density",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 sdfbbn_1 = logic_module(
-    "sdfbbn_1",
+    "sky130_fd_sc_hd__sdfbbn_1",
     "High Density",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbn_2 = logic_module(
-    "sdfbbn_2",
+    "sky130_fd_sc_hd__sdfbbn_2",
     "High Density",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbp_1 = logic_module(
-    "sdfbbp_1",
+    "sky130_fd_sc_hd__sdfbbp_1",
     "High Density",
     [
         "CLK",
@@ -1957,187 +1975,197 @@ sdfbbp_1 = logic_module(
     ],
 )
 sdfrbp_1 = logic_module(
-    "sdfrbp_1",
+    "sky130_fd_sc_hd__sdfrbp_1",
     "High Density",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrbp_2 = logic_module(
-    "sdfrbp_2",
+    "sky130_fd_sc_hd__sdfrbp_2",
     "High Density",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrtn_1 = logic_module(
-    "sdfrtn_1",
+    "sky130_fd_sc_hd__sdfrtn_1",
     "High Density",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_1 = logic_module(
-    "sdfrtp_1",
+    "sky130_fd_sc_hd__sdfrtp_1",
     "High Density",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_2 = logic_module(
-    "sdfrtp_2",
+    "sky130_fd_sc_hd__sdfrtp_2",
     "High Density",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_4 = logic_module(
-    "sdfrtp_4",
+    "sky130_fd_sc_hd__sdfrtp_4",
     "High Density",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfsbp_1 = logic_module(
-    "sdfsbp_1",
+    "sky130_fd_sc_hd__sdfsbp_1",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfsbp_2 = logic_module(
-    "sdfsbp_2",
+    "sky130_fd_sc_hd__sdfsbp_2",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfstp_1 = logic_module(
-    "sdfstp_1",
+    "sky130_fd_sc_hd__sdfstp_1",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_2 = logic_module(
-    "sdfstp_2",
+    "sky130_fd_sc_hd__sdfstp_2",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_4 = logic_module(
-    "sdfstp_4",
+    "sky130_fd_sc_hd__sdfstp_4",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxbp_1 = logic_module(
-    "sdfxbp_1",
+    "sky130_fd_sc_hd__sdfxbp_1",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxbp_2 = logic_module(
-    "sdfxbp_2",
+    "sky130_fd_sc_hd__sdfxbp_2",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxtp_1 = logic_module(
-    "sdfxtp_1",
+    "sky130_fd_sc_hd__sdfxtp_1",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_2 = logic_module(
-    "sdfxtp_2",
+    "sky130_fd_sc_hd__sdfxtp_2",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_4 = logic_module(
-    "sdfxtp_4",
+    "sky130_fd_sc_hd__sdfxtp_4",
     "High Density",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdlclkp_1 = logic_module(
-    "sdlclkp_1",
+    "sky130_fd_sc_hd__sdlclkp_1",
     "High Density",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_2 = logic_module(
-    "sdlclkp_2",
+    "sky130_fd_sc_hd__sdlclkp_2",
     "High Density",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_4 = logic_module(
-    "sdlclkp_4",
+    "sky130_fd_sc_hd__sdlclkp_4",
     "High Density",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sedfxbp_1 = logic_module(
-    "sedfxbp_1",
+    "sky130_fd_sc_hd__sedfxbp_1",
     "High Density",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxbp_2 = logic_module(
-    "sedfxbp_2",
+    "sky130_fd_sc_hd__sedfxbp_2",
     "High Density",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxtp_1 = logic_module(
-    "sedfxtp_1",
+    "sky130_fd_sc_hd__sedfxtp_1",
     "High Density",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sedfxtp_2 = logic_module(
-    "sedfxtp_2",
+    "sky130_fd_sc_hd__sedfxtp_2",
     "High Density",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sedfxtp_4 = logic_module(
-    "sedfxtp_4",
+    "sky130_fd_sc_hd__sedfxtp_4",
     "High Density",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
-tap_1 = logic_module("tap_1", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-tap_2 = logic_module("tap_2", "High Density", ["VGND", "VNB", "VPB", "VPWR"])
-tapvgnd2_1 = logic_module("tapvgnd2_1", "High Density", ["VGND", "VPB", "VPWR"])
-tapvgnd_1 = logic_module("tapvgnd_1", "High Density", ["VGND", "VPB", "VPWR"])
-tapvpwrvgnd_1 = logic_module("tapvpwrvgnd_1", "High Density", ["VGND", "VPWR"])
+tap_1 = logic_module(
+    "sky130_fd_sc_hd__tap_1", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tap_2 = logic_module(
+    "sky130_fd_sc_hd__tap_2", "High Density", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tapvgnd2_1 = logic_module(
+    "sky130_fd_sc_hd__tapvgnd2_1", "High Density", ["VGND", "VPB", "VPWR"]
+)
+tapvgnd_1 = logic_module(
+    "sky130_fd_sc_hd__tapvgnd_1", "High Density", ["VGND", "VPB", "VPWR"]
+)
+tapvpwrvgnd_1 = logic_module(
+    "sky130_fd_sc_hd__tapvpwrvgnd_1", "High Density", ["VGND", "VPWR"]
+)
 xnor2_1 = logic_module(
-    "xnor2_1",
+    "sky130_fd_sc_hd__xnor2_1",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_2 = logic_module(
-    "xnor2_2",
+    "sky130_fd_sc_hd__xnor2_2",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_4 = logic_module(
-    "xnor2_4",
+    "sky130_fd_sc_hd__xnor2_4",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor3_1 = logic_module(
-    "xnor3_1",
+    "sky130_fd_sc_hd__xnor3_1",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_2 = logic_module(
-    "xnor3_2",
+    "sky130_fd_sc_hd__xnor3_2",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_4 = logic_module(
-    "xnor3_4",
+    "sky130_fd_sc_hd__xnor3_4",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_1 = logic_module(
-    "xor2_1",
+    "sky130_fd_sc_hd__xor2_1",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_2 = logic_module(
-    "xor2_2",
+    "sky130_fd_sc_hd__xor2_2",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_4 = logic_module(
-    "xor2_4",
+    "sky130_fd_sc_hd__xor2_4",
     "High Density",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_1 = logic_module(
-    "xor3_1",
+    "sky130_fd_sc_hd__xor3_1",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_2 = logic_module(
-    "xor3_2",
+    "sky130_fd_sc_hd__xor3_2",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_4 = logic_module(
-    "xor3_4",
+    "sky130_fd_sc_hd__xor3_4",
     "High Density",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )

--- a/pdks/Sky130/sky130_hdl21/digital_cells/high_speed.py
+++ b/pdks/Sky130/sky130_hdl21/digital_cells/high_speed.py
@@ -1,1680 +1,1708 @@
 from ..pdk_data import logic_module
 
 a2bb2o_1 = logic_module(
-    "a2bb2o_1",
+    "sky130_fd_sc_hs__a2bb2o_1",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_2 = logic_module(
-    "a2bb2o_2",
+    "sky130_fd_sc_hs__a2bb2o_2",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_4 = logic_module(
-    "a2bb2o_4",
+    "sky130_fd_sc_hs__a2bb2o_4",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2oi_1 = logic_module(
-    "a2bb2oi_1",
+    "sky130_fd_sc_hs__a2bb2oi_1",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_2 = logic_module(
-    "a2bb2oi_2",
+    "sky130_fd_sc_hs__a2bb2oi_2",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_4 = logic_module(
-    "a2bb2oi_4",
+    "sky130_fd_sc_hs__a2bb2oi_4",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21bo_1 = logic_module(
-    "a21bo_1",
+    "sky130_fd_sc_hs__a21bo_1",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_2 = logic_module(
-    "a21bo_2",
+    "sky130_fd_sc_hs__a21bo_2",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_4 = logic_module(
-    "a21bo_4",
+    "sky130_fd_sc_hs__a21bo_4",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21boi_1 = logic_module(
-    "a21boi_1",
+    "sky130_fd_sc_hs__a21boi_1",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_2 = logic_module(
-    "a21boi_2",
+    "sky130_fd_sc_hs__a21boi_2",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_4 = logic_module(
-    "a21boi_4",
+    "sky130_fd_sc_hs__a21boi_4",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21o_1 = logic_module(
-    "a21o_1",
+    "sky130_fd_sc_hs__a21o_1",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_2 = logic_module(
-    "a21o_2",
+    "sky130_fd_sc_hs__a21o_2",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_4 = logic_module(
-    "a21o_4",
+    "sky130_fd_sc_hs__a21o_4",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21oi_1 = logic_module(
-    "a21oi_1",
+    "sky130_fd_sc_hs__a21oi_1",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_2 = logic_module(
-    "a21oi_2",
+    "sky130_fd_sc_hs__a21oi_2",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_4 = logic_module(
-    "a21oi_4",
+    "sky130_fd_sc_hs__a21oi_4",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22o_1 = logic_module(
-    "a22o_1",
+    "sky130_fd_sc_hs__a22o_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_2 = logic_module(
-    "a22o_2",
+    "sky130_fd_sc_hs__a22o_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_4 = logic_module(
-    "a22o_4",
+    "sky130_fd_sc_hs__a22o_4",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22oi_1 = logic_module(
-    "a22oi_1",
+    "sky130_fd_sc_hs__a22oi_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_2 = logic_module(
-    "a22oi_2",
+    "sky130_fd_sc_hs__a22oi_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_4 = logic_module(
-    "a22oi_4",
+    "sky130_fd_sc_hs__a22oi_4",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31o_1 = logic_module(
-    "a31o_1",
+    "sky130_fd_sc_hs__a31o_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_2 = logic_module(
-    "a31o_2",
+    "sky130_fd_sc_hs__a31o_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_4 = logic_module(
-    "a31o_4",
+    "sky130_fd_sc_hs__a31o_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31oi_1 = logic_module(
-    "a31oi_1",
+    "sky130_fd_sc_hs__a31oi_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_2 = logic_module(
-    "a31oi_2",
+    "sky130_fd_sc_hs__a31oi_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_4 = logic_module(
-    "a31oi_4",
+    "sky130_fd_sc_hs__a31oi_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32o_1 = logic_module(
-    "a32o_1",
+    "sky130_fd_sc_hs__a32o_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_2 = logic_module(
-    "a32o_2",
+    "sky130_fd_sc_hs__a32o_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_4 = logic_module(
-    "a32o_4",
+    "sky130_fd_sc_hs__a32o_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32oi_1 = logic_module(
-    "a32oi_1",
+    "sky130_fd_sc_hs__a32oi_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_2 = logic_module(
-    "a32oi_2",
+    "sky130_fd_sc_hs__a32oi_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_4 = logic_module(
-    "a32oi_4",
+    "sky130_fd_sc_hs__a32oi_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41o_1 = logic_module(
-    "a41o_1",
+    "sky130_fd_sc_hs__a41o_1",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_2 = logic_module(
-    "a41o_2",
+    "sky130_fd_sc_hs__a41o_2",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_4 = logic_module(
-    "a41o_4",
+    "sky130_fd_sc_hs__a41o_4",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41oi_1 = logic_module(
-    "a41oi_1",
+    "sky130_fd_sc_hs__a41oi_1",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_2 = logic_module(
-    "a41oi_2",
+    "sky130_fd_sc_hs__a41oi_2",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_4 = logic_module(
-    "a41oi_4",
+    "sky130_fd_sc_hs__a41oi_4",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211o_1 = logic_module(
-    "a211o_1",
+    "sky130_fd_sc_hs__a211o_1",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_2 = logic_module(
-    "a211o_2",
+    "sky130_fd_sc_hs__a211o_2",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_4 = logic_module(
-    "a211o_4",
+    "sky130_fd_sc_hs__a211o_4",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211oi_1 = logic_module(
-    "a211oi_1",
+    "sky130_fd_sc_hs__a211oi_1",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_2 = logic_module(
-    "a211oi_2",
+    "sky130_fd_sc_hs__a211oi_2",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_4 = logic_module(
-    "a211oi_4",
+    "sky130_fd_sc_hs__a211oi_4",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221o_1 = logic_module(
-    "a221o_1",
+    "sky130_fd_sc_hs__a221o_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_2 = logic_module(
-    "a221o_2",
+    "sky130_fd_sc_hs__a221o_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_4 = logic_module(
-    "a221o_4",
+    "sky130_fd_sc_hs__a221o_4",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221oi_1 = logic_module(
-    "a221oi_1",
+    "sky130_fd_sc_hs__a221oi_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_2 = logic_module(
-    "a221oi_2",
+    "sky130_fd_sc_hs__a221oi_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_4 = logic_module(
-    "a221oi_4",
+    "sky130_fd_sc_hs__a221oi_4",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a222o_1 = logic_module(
-    "a222o_1",
+    "sky130_fd_sc_hs__a222o_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a222o_2 = logic_module(
-    "a222o_2",
+    "sky130_fd_sc_hs__a222o_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a222oi_1 = logic_module(
-    "a222oi_1",
+    "sky130_fd_sc_hs__a222oi_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a222oi_2 = logic_module(
-    "a222oi_2",
+    "sky130_fd_sc_hs__a222oi_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311o_1 = logic_module(
-    "a311o_1",
+    "sky130_fd_sc_hs__a311o_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_2 = logic_module(
-    "a311o_2",
+    "sky130_fd_sc_hs__a311o_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_4 = logic_module(
-    "a311o_4",
+    "sky130_fd_sc_hs__a311o_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311oi_1 = logic_module(
-    "a311oi_1",
+    "sky130_fd_sc_hs__a311oi_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_2 = logic_module(
-    "a311oi_2",
+    "sky130_fd_sc_hs__a311oi_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_4 = logic_module(
-    "a311oi_4",
+    "sky130_fd_sc_hs__a311oi_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111o_1 = logic_module(
-    "a2111o_1",
+    "sky130_fd_sc_hs__a2111o_1",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_2 = logic_module(
-    "a2111o_2",
+    "sky130_fd_sc_hs__a2111o_2",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_4 = logic_module(
-    "a2111o_4",
+    "sky130_fd_sc_hs__a2111o_4",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111oi_1 = logic_module(
-    "a2111oi_1",
+    "sky130_fd_sc_hs__a2111oi_1",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_2 = logic_module(
-    "a2111oi_2",
+    "sky130_fd_sc_hs__a2111oi_2",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_4 = logic_module(
-    "a2111oi_4",
+    "sky130_fd_sc_hs__a2111oi_4",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 and2_1 = logic_module(
-    "and2_1",
+    "sky130_fd_sc_hs__and2_1",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_2 = logic_module(
-    "and2_2",
+    "sky130_fd_sc_hs__and2_2",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_4 = logic_module(
-    "and2_4",
+    "sky130_fd_sc_hs__and2_4",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_1 = logic_module(
-    "and2b_1",
+    "sky130_fd_sc_hs__and2b_1",
     "High Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_2 = logic_module(
-    "and2b_2",
+    "sky130_fd_sc_hs__and2b_2",
     "High Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_4 = logic_module(
-    "and2b_4",
+    "sky130_fd_sc_hs__and2b_4",
     "High Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_1 = logic_module(
-    "and3_1",
+    "sky130_fd_sc_hs__and3_1",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_2 = logic_module(
-    "and3_2",
+    "sky130_fd_sc_hs__and3_2",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_4 = logic_module(
-    "and3_4",
+    "sky130_fd_sc_hs__and3_4",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_1 = logic_module(
-    "and3b_1",
+    "sky130_fd_sc_hs__and3b_1",
     "High Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_2 = logic_module(
-    "and3b_2",
+    "sky130_fd_sc_hs__and3b_2",
     "High Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_4 = logic_module(
-    "and3b_4",
+    "sky130_fd_sc_hs__and3b_4",
     "High Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_1 = logic_module(
-    "and4_1",
+    "sky130_fd_sc_hs__and4_1",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_2 = logic_module(
-    "and4_2",
+    "sky130_fd_sc_hs__and4_2",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_4 = logic_module(
-    "and4_4",
+    "sky130_fd_sc_hs__and4_4",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_1 = logic_module(
-    "and4b_1",
+    "sky130_fd_sc_hs__and4b_1",
     "High Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_2 = logic_module(
-    "and4b_2",
+    "sky130_fd_sc_hs__and4b_2",
     "High Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_4 = logic_module(
-    "and4b_4",
+    "sky130_fd_sc_hs__and4b_4",
     "High Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_1 = logic_module(
-    "and4bb_1",
+    "sky130_fd_sc_hs__and4bb_1",
     "High Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_2 = logic_module(
-    "and4bb_2",
+    "sky130_fd_sc_hs__and4bb_2",
     "High Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_4 = logic_module(
-    "and4bb_4",
+    "sky130_fd_sc_hs__and4bb_4",
     "High Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
-buf_1 = logic_module("buf_1", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_2 = logic_module("buf_2", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_4 = logic_module("buf_4", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_8 = logic_module("buf_8", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
+buf_1 = logic_module(
+    "sky130_fd_sc_hs__buf_1", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_2 = logic_module(
+    "sky130_fd_sc_hs__buf_2", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_4 = logic_module(
+    "sky130_fd_sc_hs__buf_4", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_8 = logic_module(
+    "sky130_fd_sc_hs__buf_8", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
 buf_16 = logic_module(
-    "buf_16",
+    "sky130_fd_sc_hs__buf_16",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_8 = logic_module(
-    "bufbuf_8",
+    "sky130_fd_sc_hs__bufbuf_8",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_16 = logic_module(
-    "bufbuf_16",
+    "sky130_fd_sc_hs__bufbuf_16",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufinv_8 = logic_module(
-    "bufinv_8",
+    "sky130_fd_sc_hs__bufinv_8",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 bufinv_16 = logic_module(
-    "bufinv_16",
+    "sky130_fd_sc_hs__bufinv_16",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkbuf_1 = logic_module(
-    "clkbuf_1",
+    "sky130_fd_sc_hs__clkbuf_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_2 = logic_module(
-    "clkbuf_2",
+    "sky130_fd_sc_hs__clkbuf_2",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_4 = logic_module(
-    "clkbuf_4",
+    "sky130_fd_sc_hs__clkbuf_4",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_8 = logic_module(
-    "clkbuf_8",
+    "sky130_fd_sc_hs__clkbuf_8",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_16 = logic_module(
-    "clkbuf_16",
+    "sky130_fd_sc_hs__clkbuf_16",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlyinv3sd1_1 = logic_module(
-    "clkdlyinv3sd1_1",
+    "sky130_fd_sc_hs__clkdlyinv3sd1_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv3sd2_1 = logic_module(
-    "clkdlyinv3sd2_1",
+    "sky130_fd_sc_hs__clkdlyinv3sd2_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv3sd3_1 = logic_module(
-    "clkdlyinv3sd3_1",
+    "sky130_fd_sc_hs__clkdlyinv3sd3_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd1_1 = logic_module(
-    "clkdlyinv5sd1_1",
+    "sky130_fd_sc_hs__clkdlyinv5sd1_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd2_1 = logic_module(
-    "clkdlyinv5sd2_1",
+    "sky130_fd_sc_hs__clkdlyinv5sd2_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd3_1 = logic_module(
-    "clkdlyinv5sd3_1",
+    "sky130_fd_sc_hs__clkdlyinv5sd3_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_1 = logic_module(
-    "clkinv_1",
+    "sky130_fd_sc_hs__clkinv_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_2 = logic_module(
-    "clkinv_2",
+    "sky130_fd_sc_hs__clkinv_2",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_4 = logic_module(
-    "clkinv_4",
+    "sky130_fd_sc_hs__clkinv_4",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_8 = logic_module(
-    "clkinv_8",
+    "sky130_fd_sc_hs__clkinv_8",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_16 = logic_module(
-    "clkinv_16",
+    "sky130_fd_sc_hs__clkinv_16",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 conb_1 = logic_module(
-    "conb_1",
+    "sky130_fd_sc_hs__conb_1",
     "High Speed",
     ["VGND", "VNB", "VPB", "VPWR", "HI", "LO"],
 )
-decap_4 = logic_module("decap_4", "High Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decap_8 = logic_module("decap_8", "High Speed", ["VGND", "VNB", "VPB", "VPWR"])
+decap_4 = logic_module(
+    "sky130_fd_sc_hs__decap_4", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_8 = logic_module(
+    "sky130_fd_sc_hs__decap_8", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
 dfbbn_1 = logic_module(
-    "dfbbn_1",
+    "sky130_fd_sc_hs__dfbbn_1",
     "High Speed",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbn_2 = logic_module(
-    "dfbbn_2",
+    "sky130_fd_sc_hs__dfbbn_2",
     "High Speed",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbp_1 = logic_module(
-    "dfbbp_1",
+    "sky130_fd_sc_hs__dfbbp_1",
     "High Speed",
     ["CLK", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_1 = logic_module(
-    "dfrbp_1",
+    "sky130_fd_sc_hs__dfrbp_1",
     "High Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_2 = logic_module(
-    "dfrbp_2",
+    "sky130_fd_sc_hs__dfrbp_2",
     "High Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrtn_1 = logic_module(
-    "dfrtn_1",
+    "sky130_fd_sc_hs__dfrtn_1",
     "High Speed",
     ["CLK_N", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_1 = logic_module(
-    "dfrtp_1",
+    "sky130_fd_sc_hs__dfrtp_1",
     "High Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_2 = logic_module(
-    "dfrtp_2",
+    "sky130_fd_sc_hs__dfrtp_2",
     "High Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_4 = logic_module(
-    "dfrtp_4",
+    "sky130_fd_sc_hs__dfrtp_4",
     "High Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfsbp_1 = logic_module(
-    "dfsbp_1",
+    "sky130_fd_sc_hs__dfsbp_1",
     "High Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfsbp_2 = logic_module(
-    "dfsbp_2",
+    "sky130_fd_sc_hs__dfsbp_2",
     "High Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfstp_1 = logic_module(
-    "dfstp_1",
+    "sky130_fd_sc_hs__dfstp_1",
     "High Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_2 = logic_module(
-    "dfstp_2",
+    "sky130_fd_sc_hs__dfstp_2",
     "High Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_4 = logic_module(
-    "dfstp_4",
+    "sky130_fd_sc_hs__dfstp_4",
     "High Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxbp_1 = logic_module(
-    "dfxbp_1",
+    "sky130_fd_sc_hs__dfxbp_1",
     "High Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxbp_2 = logic_module(
-    "dfxbp_2",
+    "sky130_fd_sc_hs__dfxbp_2",
     "High Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxtp_1 = logic_module(
-    "dfxtp_1",
+    "sky130_fd_sc_hs__dfxtp_1",
     "High Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_2 = logic_module(
-    "dfxtp_2",
+    "sky130_fd_sc_hs__dfxtp_2",
     "High Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_4 = logic_module(
-    "dfxtp_4",
+    "sky130_fd_sc_hs__dfxtp_4",
     "High Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 diode_2 = logic_module(
-    "diode_2",
+    "sky130_fd_sc_hs__diode_2",
     "High Speed",
     ["DIODE", "VGND", "VNB", "VPB", "VPWR"],
 )
 dlclkp_1 = logic_module(
-    "dlclkp_1",
+    "sky130_fd_sc_hs__dlclkp_1",
     "High Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_2 = logic_module(
-    "dlclkp_2",
+    "sky130_fd_sc_hs__dlclkp_2",
     "High Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_4 = logic_module(
-    "dlclkp_4",
+    "sky130_fd_sc_hs__dlclkp_4",
     "High Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlrbn_1 = logic_module(
-    "dlrbn_1",
+    "sky130_fd_sc_hs__dlrbn_1",
     "High Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbn_2 = logic_module(
-    "dlrbn_2",
+    "sky130_fd_sc_hs__dlrbn_2",
     "High Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_1 = logic_module(
-    "dlrbp_1",
+    "sky130_fd_sc_hs__dlrbp_1",
     "High Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_2 = logic_module(
-    "dlrbp_2",
+    "sky130_fd_sc_hs__dlrbp_2",
     "High Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrtn_1 = logic_module(
-    "dlrtn_1",
+    "sky130_fd_sc_hs__dlrtn_1",
     "High Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_2 = logic_module(
-    "dlrtn_2",
+    "sky130_fd_sc_hs__dlrtn_2",
     "High Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_4 = logic_module(
-    "dlrtn_4",
+    "sky130_fd_sc_hs__dlrtn_4",
     "High Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_1 = logic_module(
-    "dlrtp_1",
+    "sky130_fd_sc_hs__dlrtp_1",
     "High Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_2 = logic_module(
-    "dlrtp_2",
+    "sky130_fd_sc_hs__dlrtp_2",
     "High Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_4 = logic_module(
-    "dlrtp_4",
+    "sky130_fd_sc_hs__dlrtp_4",
     "High Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxbn_1 = logic_module(
-    "dlxbn_1",
+    "sky130_fd_sc_hs__dlxbn_1",
     "High Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbn_2 = logic_module(
-    "dlxbn_2",
+    "sky130_fd_sc_hs__dlxbn_2",
     "High Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbp_1 = logic_module(
-    "dlxbp_1",
+    "sky130_fd_sc_hs__dlxbp_1",
     "High Speed",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxtn_1 = logic_module(
-    "dlxtn_1",
+    "sky130_fd_sc_hs__dlxtn_1",
     "High Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_2 = logic_module(
-    "dlxtn_2",
+    "sky130_fd_sc_hs__dlxtn_2",
     "High Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_4 = logic_module(
-    "dlxtn_4",
+    "sky130_fd_sc_hs__dlxtn_4",
     "High Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtp_1 = logic_module(
-    "dlxtp_1",
+    "sky130_fd_sc_hs__dlxtp_1",
     "High Speed",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlygate4sd1_1 = logic_module(
-    "dlygate4sd1_1",
+    "sky130_fd_sc_hs__dlygate4sd1_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd2_1 = logic_module(
-    "dlygate4sd2_1",
+    "sky130_fd_sc_hs__dlygate4sd2_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd3_1 = logic_module(
-    "dlygate4sd3_1",
+    "sky130_fd_sc_hs__dlygate4sd3_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s2s_1 = logic_module(
-    "dlymetal6s2s_1",
+    "sky130_fd_sc_hs__dlymetal6s2s_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s4s_1 = logic_module(
-    "dlymetal6s4s_1",
+    "sky130_fd_sc_hs__dlymetal6s4s_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s6s_1 = logic_module(
-    "dlymetal6s6s_1",
+    "sky130_fd_sc_hs__dlymetal6s6s_1",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 ebufn_1 = logic_module(
-    "ebufn_1",
+    "sky130_fd_sc_hs__ebufn_1",
     "High Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_2 = logic_module(
-    "ebufn_2",
+    "sky130_fd_sc_hs__ebufn_2",
     "High Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_4 = logic_module(
-    "ebufn_4",
+    "sky130_fd_sc_hs__ebufn_4",
     "High Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_8 = logic_module(
-    "ebufn_8",
+    "sky130_fd_sc_hs__ebufn_8",
     "High Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 edfxbp_1 = logic_module(
-    "edfxbp_1",
+    "sky130_fd_sc_hs__edfxbp_1",
     "High Speed",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 edfxtp_1 = logic_module(
-    "edfxtp_1",
+    "sky130_fd_sc_hs__edfxtp_1",
     "High Speed",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 einvn_1 = logic_module(
-    "einvn_1",
+    "sky130_fd_sc_hs__einvn_1",
     "High Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_2 = logic_module(
-    "einvn_2",
+    "sky130_fd_sc_hs__einvn_2",
     "High Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_4 = logic_module(
-    "einvn_4",
+    "sky130_fd_sc_hs__einvn_4",
     "High Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_8 = logic_module(
-    "einvn_8",
+    "sky130_fd_sc_hs__einvn_8",
     "High Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_1 = logic_module(
-    "einvp_1",
+    "sky130_fd_sc_hs__einvp_1",
     "High Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_2 = logic_module(
-    "einvp_2",
+    "sky130_fd_sc_hs__einvp_2",
     "High Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_4 = logic_module(
-    "einvp_4",
+    "sky130_fd_sc_hs__einvp_4",
     "High Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_8 = logic_module(
-    "einvp_8",
+    "sky130_fd_sc_hs__einvp_8",
     "High Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 fa_1 = logic_module(
-    "fa_1",
+    "sky130_fd_sc_hs__fa_1",
     "High Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_2 = logic_module(
-    "fa_2",
+    "sky130_fd_sc_hs__fa_2",
     "High Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_4 = logic_module(
-    "fa_4",
+    "sky130_fd_sc_hs__fa_4",
     "High Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_1 = logic_module(
-    "fah_1",
+    "sky130_fd_sc_hs__fah_1",
     "High Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_2 = logic_module(
-    "fah_2",
+    "sky130_fd_sc_hs__fah_2",
     "High Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_4 = logic_module(
-    "fah_4",
+    "sky130_fd_sc_hs__fah_4",
     "High Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcin_1 = logic_module(
-    "fahcin_1",
+    "sky130_fd_sc_hs__fahcin_1",
     "High Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcon_1 = logic_module(
-    "fahcon_1",
+    "sky130_fd_sc_hs__fahcon_1",
     "High Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT_N", "SUM"],
 )
-fill_1 = logic_module("fill_1", "High Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_2 = logic_module("fill_2", "High Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_4 = logic_module("fill_4", "High Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_8 = logic_module("fill_8", "High Speed", ["VGND", "VNB", "VPB", "VPWR"])
+fill_1 = logic_module(
+    "sky130_fd_sc_hs__fill_1", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_2 = logic_module(
+    "sky130_fd_sc_hs__fill_2", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_4 = logic_module(
+    "sky130_fd_sc_hs__fill_4", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_8 = logic_module(
+    "sky130_fd_sc_hs__fill_8", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
 fill_diode_2 = logic_module(
-    "fill_diode_2", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+    "sky130_fd_sc_hs__fill_diode_2", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
 )
 fill_diode_4 = logic_module(
-    "fill_diode_4", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+    "sky130_fd_sc_hs__fill_diode_4", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
 )
 fill_diode_8 = logic_module(
-    "fill_diode_8", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+    "sky130_fd_sc_hs__fill_diode_8", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
 )
 ha_1 = logic_module(
-    "ha_1",
+    "sky130_fd_sc_hs__ha_1",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_2 = logic_module(
-    "ha_2",
+    "sky130_fd_sc_hs__ha_2",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_4 = logic_module(
-    "ha_4",
+    "sky130_fd_sc_hs__ha_4",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
-inv_1 = logic_module("inv_1", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_2 = logic_module("inv_2", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_4 = logic_module("inv_4", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_8 = logic_module("inv_8", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
+inv_1 = logic_module(
+    "sky130_fd_sc_hs__inv_1", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_2 = logic_module(
+    "sky130_fd_sc_hs__inv_2", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_4 = logic_module(
+    "sky130_fd_sc_hs__inv_4", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_8 = logic_module(
+    "sky130_fd_sc_hs__inv_8", "High Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
 inv_16 = logic_module(
-    "inv_16",
+    "sky130_fd_sc_hs__inv_16",
     "High Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 maj3_1 = logic_module(
-    "maj3_1",
+    "sky130_fd_sc_hs__maj3_1",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_2 = logic_module(
-    "maj3_2",
+    "sky130_fd_sc_hs__maj3_2",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_4 = logic_module(
-    "maj3_4",
+    "sky130_fd_sc_hs__maj3_4",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_1 = logic_module(
-    "mux2_1",
+    "sky130_fd_sc_hs__mux2_1",
     "High Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_2 = logic_module(
-    "mux2_2",
+    "sky130_fd_sc_hs__mux2_2",
     "High Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_4 = logic_module(
-    "mux2_4",
+    "sky130_fd_sc_hs__mux2_4",
     "High Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2i_1 = logic_module(
-    "mux2i_1",
+    "sky130_fd_sc_hs__mux2i_1",
     "High Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_2 = logic_module(
-    "mux2i_2",
+    "sky130_fd_sc_hs__mux2i_2",
     "High Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_4 = logic_module(
-    "mux2i_4",
+    "sky130_fd_sc_hs__mux2i_4",
     "High Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux4_1 = logic_module(
-    "mux4_1",
+    "sky130_fd_sc_hs__mux4_1",
     "High Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_2 = logic_module(
-    "mux4_2",
+    "sky130_fd_sc_hs__mux4_2",
     "High Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_4 = logic_module(
-    "mux4_4",
+    "sky130_fd_sc_hs__mux4_4",
     "High Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 nand2_1 = logic_module(
-    "nand2_1",
+    "sky130_fd_sc_hs__nand2_1",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_2 = logic_module(
-    "nand2_2",
+    "sky130_fd_sc_hs__nand2_2",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_4 = logic_module(
-    "nand2_4",
+    "sky130_fd_sc_hs__nand2_4",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_8 = logic_module(
-    "nand2_8",
+    "sky130_fd_sc_hs__nand2_8",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_1 = logic_module(
-    "nand2b_1",
+    "sky130_fd_sc_hs__nand2b_1",
     "High Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_2 = logic_module(
-    "nand2b_2",
+    "sky130_fd_sc_hs__nand2b_2",
     "High Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_4 = logic_module(
-    "nand2b_4",
+    "sky130_fd_sc_hs__nand2b_4",
     "High Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_1 = logic_module(
-    "nand3_1",
+    "sky130_fd_sc_hs__nand3_1",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_2 = logic_module(
-    "nand3_2",
+    "sky130_fd_sc_hs__nand3_2",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_4 = logic_module(
-    "nand3_4",
+    "sky130_fd_sc_hs__nand3_4",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_1 = logic_module(
-    "nand3b_1",
+    "sky130_fd_sc_hs__nand3b_1",
     "High Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_2 = logic_module(
-    "nand3b_2",
+    "sky130_fd_sc_hs__nand3b_2",
     "High Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_4 = logic_module(
-    "nand3b_4",
+    "sky130_fd_sc_hs__nand3b_4",
     "High Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_1 = logic_module(
-    "nand4_1",
+    "sky130_fd_sc_hs__nand4_1",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_2 = logic_module(
-    "nand4_2",
+    "sky130_fd_sc_hs__nand4_2",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_4 = logic_module(
-    "nand4_4",
+    "sky130_fd_sc_hs__nand4_4",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_1 = logic_module(
-    "nand4b_1",
+    "sky130_fd_sc_hs__nand4b_1",
     "High Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_2 = logic_module(
-    "nand4b_2",
+    "sky130_fd_sc_hs__nand4b_2",
     "High Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_4 = logic_module(
-    "nand4b_4",
+    "sky130_fd_sc_hs__nand4b_4",
     "High Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_1 = logic_module(
-    "nand4bb_1",
+    "sky130_fd_sc_hs__nand4bb_1",
     "High Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_2 = logic_module(
-    "nand4bb_2",
+    "sky130_fd_sc_hs__nand4bb_2",
     "High Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_4 = logic_module(
-    "nand4bb_4",
+    "sky130_fd_sc_hs__nand4bb_4",
     "High Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_1 = logic_module(
-    "nor2_1",
+    "sky130_fd_sc_hs__nor2_1",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_2 = logic_module(
-    "nor2_2",
+    "sky130_fd_sc_hs__nor2_2",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_4 = logic_module(
-    "nor2_4",
+    "sky130_fd_sc_hs__nor2_4",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_8 = logic_module(
-    "nor2_8",
+    "sky130_fd_sc_hs__nor2_8",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_1 = logic_module(
-    "nor2b_1",
+    "sky130_fd_sc_hs__nor2b_1",
     "High Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_2 = logic_module(
-    "nor2b_2",
+    "sky130_fd_sc_hs__nor2b_2",
     "High Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_4 = logic_module(
-    "nor2b_4",
+    "sky130_fd_sc_hs__nor2b_4",
     "High Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_1 = logic_module(
-    "nor3_1",
+    "sky130_fd_sc_hs__nor3_1",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_2 = logic_module(
-    "nor3_2",
+    "sky130_fd_sc_hs__nor3_2",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_4 = logic_module(
-    "nor3_4",
+    "sky130_fd_sc_hs__nor3_4",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_1 = logic_module(
-    "nor3b_1",
+    "sky130_fd_sc_hs__nor3b_1",
     "High Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_2 = logic_module(
-    "nor3b_2",
+    "sky130_fd_sc_hs__nor3b_2",
     "High Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_4 = logic_module(
-    "nor3b_4",
+    "sky130_fd_sc_hs__nor3b_4",
     "High Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_1 = logic_module(
-    "nor4_1",
+    "sky130_fd_sc_hs__nor4_1",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_2 = logic_module(
-    "nor4_2",
+    "sky130_fd_sc_hs__nor4_2",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_4 = logic_module(
-    "nor4_4",
+    "sky130_fd_sc_hs__nor4_4",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_1 = logic_module(
-    "nor4b_1",
+    "sky130_fd_sc_hs__nor4b_1",
     "High Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_2 = logic_module(
-    "nor4b_2",
+    "sky130_fd_sc_hs__nor4b_2",
     "High Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_4 = logic_module(
-    "nor4b_4",
+    "sky130_fd_sc_hs__nor4b_4",
     "High Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_1 = logic_module(
-    "nor4bb_1",
+    "sky130_fd_sc_hs__nor4bb_1",
     "High Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_2 = logic_module(
-    "nor4bb_2",
+    "sky130_fd_sc_hs__nor4bb_2",
     "High Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_4 = logic_module(
-    "nor4bb_4",
+    "sky130_fd_sc_hs__nor4bb_4",
     "High Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2a_1 = logic_module(
-    "o2bb2a_1",
+    "sky130_fd_sc_hs__o2bb2a_1",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_2 = logic_module(
-    "o2bb2a_2",
+    "sky130_fd_sc_hs__o2bb2a_2",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_4 = logic_module(
-    "o2bb2a_4",
+    "sky130_fd_sc_hs__o2bb2a_4",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2ai_1 = logic_module(
-    "o2bb2ai_1",
+    "sky130_fd_sc_hs__o2bb2ai_1",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_2 = logic_module(
-    "o2bb2ai_2",
+    "sky130_fd_sc_hs__o2bb2ai_2",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_4 = logic_module(
-    "o2bb2ai_4",
+    "sky130_fd_sc_hs__o2bb2ai_4",
     "High Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21a_1 = logic_module(
-    "o21a_1",
+    "sky130_fd_sc_hs__o21a_1",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_2 = logic_module(
-    "o21a_2",
+    "sky130_fd_sc_hs__o21a_2",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_4 = logic_module(
-    "o21a_4",
+    "sky130_fd_sc_hs__o21a_4",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ai_1 = logic_module(
-    "o21ai_1",
+    "sky130_fd_sc_hs__o21ai_1",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_2 = logic_module(
-    "o21ai_2",
+    "sky130_fd_sc_hs__o21ai_2",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_4 = logic_module(
-    "o21ai_4",
+    "sky130_fd_sc_hs__o21ai_4",
     "High Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ba_1 = logic_module(
-    "o21ba_1",
+    "sky130_fd_sc_hs__o21ba_1",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_2 = logic_module(
-    "o21ba_2",
+    "sky130_fd_sc_hs__o21ba_2",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_4 = logic_module(
-    "o21ba_4",
+    "sky130_fd_sc_hs__o21ba_4",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21bai_1 = logic_module(
-    "o21bai_1",
+    "sky130_fd_sc_hs__o21bai_1",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_2 = logic_module(
-    "o21bai_2",
+    "sky130_fd_sc_hs__o21bai_2",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_4 = logic_module(
-    "o21bai_4",
+    "sky130_fd_sc_hs__o21bai_4",
     "High Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22a_1 = logic_module(
-    "o22a_1",
+    "sky130_fd_sc_hs__o22a_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_2 = logic_module(
-    "o22a_2",
+    "sky130_fd_sc_hs__o22a_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_4 = logic_module(
-    "o22a_4",
+    "sky130_fd_sc_hs__o22a_4",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22ai_1 = logic_module(
-    "o22ai_1",
+    "sky130_fd_sc_hs__o22ai_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_2 = logic_module(
-    "o22ai_2",
+    "sky130_fd_sc_hs__o22ai_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_4 = logic_module(
-    "o22ai_4",
+    "sky130_fd_sc_hs__o22ai_4",
     "High Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31a_1 = logic_module(
-    "o31a_1",
+    "sky130_fd_sc_hs__o31a_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_2 = logic_module(
-    "o31a_2",
+    "sky130_fd_sc_hs__o31a_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_4 = logic_module(
-    "o31a_4",
+    "sky130_fd_sc_hs__o31a_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31ai_1 = logic_module(
-    "o31ai_1",
+    "sky130_fd_sc_hs__o31ai_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_2 = logic_module(
-    "o31ai_2",
+    "sky130_fd_sc_hs__o31ai_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_4 = logic_module(
-    "o31ai_4",
+    "sky130_fd_sc_hs__o31ai_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32a_1 = logic_module(
-    "o32a_1",
+    "sky130_fd_sc_hs__o32a_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_2 = logic_module(
-    "o32a_2",
+    "sky130_fd_sc_hs__o32a_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_4 = logic_module(
-    "o32a_4",
+    "sky130_fd_sc_hs__o32a_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32ai_1 = logic_module(
-    "o32ai_1",
+    "sky130_fd_sc_hs__o32ai_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_2 = logic_module(
-    "o32ai_2",
+    "sky130_fd_sc_hs__o32ai_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_4 = logic_module(
-    "o32ai_4",
+    "sky130_fd_sc_hs__o32ai_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41a_1 = logic_module(
-    "o41a_1",
+    "sky130_fd_sc_hs__o41a_1",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_2 = logic_module(
-    "o41a_2",
+    "sky130_fd_sc_hs__o41a_2",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_4 = logic_module(
-    "o41a_4",
+    "sky130_fd_sc_hs__o41a_4",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41ai_1 = logic_module(
-    "o41ai_1",
+    "sky130_fd_sc_hs__o41ai_1",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_2 = logic_module(
-    "o41ai_2",
+    "sky130_fd_sc_hs__o41ai_2",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_4 = logic_module(
-    "o41ai_4",
+    "sky130_fd_sc_hs__o41ai_4",
     "High Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211a_1 = logic_module(
-    "o211a_1",
+    "sky130_fd_sc_hs__o211a_1",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_2 = logic_module(
-    "o211a_2",
+    "sky130_fd_sc_hs__o211a_2",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_4 = logic_module(
-    "o211a_4",
+    "sky130_fd_sc_hs__o211a_4",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211ai_1 = logic_module(
-    "o211ai_1",
+    "sky130_fd_sc_hs__o211ai_1",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_2 = logic_module(
-    "o211ai_2",
+    "sky130_fd_sc_hs__o211ai_2",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_4 = logic_module(
-    "o211ai_4",
+    "sky130_fd_sc_hs__o211ai_4",
     "High Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221a_1 = logic_module(
-    "o221a_1",
+    "sky130_fd_sc_hs__o221a_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_2 = logic_module(
-    "o221a_2",
+    "sky130_fd_sc_hs__o221a_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_4 = logic_module(
-    "o221a_4",
+    "sky130_fd_sc_hs__o221a_4",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221ai_1 = logic_module(
-    "o221ai_1",
+    "sky130_fd_sc_hs__o221ai_1",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_2 = logic_module(
-    "o221ai_2",
+    "sky130_fd_sc_hs__o221ai_2",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_4 = logic_module(
-    "o221ai_4",
+    "sky130_fd_sc_hs__o221ai_4",
     "High Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311a_1 = logic_module(
-    "o311a_1",
+    "sky130_fd_sc_hs__o311a_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_2 = logic_module(
-    "o311a_2",
+    "sky130_fd_sc_hs__o311a_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_4 = logic_module(
-    "o311a_4",
+    "sky130_fd_sc_hs__o311a_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311ai_1 = logic_module(
-    "o311ai_1",
+    "sky130_fd_sc_hs__o311ai_1",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_2 = logic_module(
-    "o311ai_2",
+    "sky130_fd_sc_hs__o311ai_2",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_4 = logic_module(
-    "o311ai_4",
+    "sky130_fd_sc_hs__o311ai_4",
     "High Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111a_1 = logic_module(
-    "o2111a_1",
+    "sky130_fd_sc_hs__o2111a_1",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_2 = logic_module(
-    "o2111a_2",
+    "sky130_fd_sc_hs__o2111a_2",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_4 = logic_module(
-    "o2111a_4",
+    "sky130_fd_sc_hs__o2111a_4",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111ai_1 = logic_module(
-    "o2111ai_1",
+    "sky130_fd_sc_hs__o2111ai_1",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_2 = logic_module(
-    "o2111ai_2",
+    "sky130_fd_sc_hs__o2111ai_2",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_4 = logic_module(
-    "o2111ai_4",
+    "sky130_fd_sc_hs__o2111ai_4",
     "High Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 or2_1 = logic_module(
-    "or2_1",
+    "sky130_fd_sc_hs__or2_1",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_2 = logic_module(
-    "or2_2",
+    "sky130_fd_sc_hs__or2_2",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_4 = logic_module(
-    "or2_4",
+    "sky130_fd_sc_hs__or2_4",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_1 = logic_module(
-    "or2b_1",
+    "sky130_fd_sc_hs__or2b_1",
     "High Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_2 = logic_module(
-    "or2b_2",
+    "sky130_fd_sc_hs__or2b_2",
     "High Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_4 = logic_module(
-    "or2b_4",
+    "sky130_fd_sc_hs__or2b_4",
     "High Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_1 = logic_module(
-    "or3_1",
+    "sky130_fd_sc_hs__or3_1",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_2 = logic_module(
-    "or3_2",
+    "sky130_fd_sc_hs__or3_2",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_4 = logic_module(
-    "or3_4",
+    "sky130_fd_sc_hs__or3_4",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_1 = logic_module(
-    "or3b_1",
+    "sky130_fd_sc_hs__or3b_1",
     "High Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_2 = logic_module(
-    "or3b_2",
+    "sky130_fd_sc_hs__or3b_2",
     "High Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_4 = logic_module(
-    "or3b_4",
+    "sky130_fd_sc_hs__or3b_4",
     "High Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_1 = logic_module(
-    "or4_1",
+    "sky130_fd_sc_hs__or4_1",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_2 = logic_module(
-    "or4_2",
+    "sky130_fd_sc_hs__or4_2",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_4 = logic_module(
-    "or4_4",
+    "sky130_fd_sc_hs__or4_4",
     "High Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_1 = logic_module(
-    "or4b_1",
+    "sky130_fd_sc_hs__or4b_1",
     "High Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_2 = logic_module(
-    "or4b_2",
+    "sky130_fd_sc_hs__or4b_2",
     "High Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_4 = logic_module(
-    "or4b_4",
+    "sky130_fd_sc_hs__or4b_4",
     "High Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_1 = logic_module(
-    "or4bb_1",
+    "sky130_fd_sc_hs__or4bb_1",
     "High Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_2 = logic_module(
-    "or4bb_2",
+    "sky130_fd_sc_hs__or4bb_2",
     "High Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_4 = logic_module(
-    "or4bb_4",
+    "sky130_fd_sc_hs__or4bb_4",
     "High Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 sdfbbn_1 = logic_module(
-    "sdfbbn_1",
+    "sky130_fd_sc_hs__sdfbbn_1",
     "High Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbn_2 = logic_module(
-    "sdfbbn_2",
+    "sky130_fd_sc_hs__sdfbbn_2",
     "High Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbp_1 = logic_module(
-    "sdfbbp_1",
+    "sky130_fd_sc_hs__sdfbbp_1",
     "High Speed",
     [
         "CLK",
@@ -1691,188 +1719,200 @@ sdfbbp_1 = logic_module(
     ],
 )
 sdfrbp_1 = logic_module(
-    "sdfrbp_1",
+    "sky130_fd_sc_hs__sdfrbp_1",
     "High Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrbp_2 = logic_module(
-    "sdfrbp_2",
+    "sky130_fd_sc_hs__sdfrbp_2",
     "High Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrtn_1 = logic_module(
-    "sdfrtn_1",
+    "sky130_fd_sc_hs__sdfrtn_1",
     "High Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_1 = logic_module(
-    "sdfrtp_1",
+    "sky130_fd_sc_hs__sdfrtp_1",
     "High Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_2 = logic_module(
-    "sdfrtp_2",
+    "sky130_fd_sc_hs__sdfrtp_2",
     "High Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_4 = logic_module(
-    "sdfrtp_4",
+    "sky130_fd_sc_hs__sdfrtp_4",
     "High Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfsbp_1 = logic_module(
-    "sdfsbp_1",
+    "sky130_fd_sc_hs__sdfsbp_1",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfsbp_2 = logic_module(
-    "sdfsbp_2",
+    "sky130_fd_sc_hs__sdfsbp_2",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfstp_1 = logic_module(
-    "sdfstp_1",
+    "sky130_fd_sc_hs__sdfstp_1",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_2 = logic_module(
-    "sdfstp_2",
+    "sky130_fd_sc_hs__sdfstp_2",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_4 = logic_module(
-    "sdfstp_4",
+    "sky130_fd_sc_hs__sdfstp_4",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxbp_1 = logic_module(
-    "sdfxbp_1",
+    "sky130_fd_sc_hs__sdfxbp_1",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxbp_2 = logic_module(
-    "sdfxbp_2",
+    "sky130_fd_sc_hs__sdfxbp_2",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxtp_1 = logic_module(
-    "sdfxtp_1",
+    "sky130_fd_sc_hs__sdfxtp_1",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_2 = logic_module(
-    "sdfxtp_2",
+    "sky130_fd_sc_hs__sdfxtp_2",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_4 = logic_module(
-    "sdfxtp_4",
+    "sky130_fd_sc_hs__sdfxtp_4",
     "High Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdlclkp_1 = logic_module(
-    "sdlclkp_1",
+    "sky130_fd_sc_hs__sdlclkp_1",
     "High Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_2 = logic_module(
-    "sdlclkp_2",
+    "sky130_fd_sc_hs__sdlclkp_2",
     "High Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_4 = logic_module(
-    "sdlclkp_4",
+    "sky130_fd_sc_hs__sdlclkp_4",
     "High Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sedfxbp_1 = logic_module(
-    "sedfxbp_1",
+    "sky130_fd_sc_hs__sedfxbp_1",
     "High Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxbp_2 = logic_module(
-    "sedfxbp_2",
+    "sky130_fd_sc_hs__sedfxbp_2",
     "High Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxtp_1 = logic_module(
-    "sedfxtp_1",
+    "sky130_fd_sc_hs__sedfxtp_1",
     "High Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sedfxtp_2 = logic_module(
-    "sedfxtp_2",
+    "sky130_fd_sc_hs__sedfxtp_2",
     "High Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sedfxtp_4 = logic_module(
-    "sedfxtp_4",
+    "sky130_fd_sc_hs__sedfxtp_4",
     "High Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
-tap_1 = logic_module("tap_1", "High Speed", ["VGND", "VNB", "VPB", "VPWR"])
-tap_2 = logic_module("tap_2", "High Speed", ["VGND", "VNB", "VPB", "VPWR"])
-tapmet1_2 = logic_module("tapmet1_2", "High Speed", ["VGND", "VPB", "VPWR"])
-tapvgnd2_1 = logic_module("tapvgnd2_1", "High Speed", ["VGND", "VPB", "VPWR"])
-tapvgnd_1 = logic_module("tapvgnd_1", "High Speed", ["VGND", "VPB", "VPWR"])
-tapvpwrvgnd_1 = logic_module("tapvpwrvgnd_1", "High Speed", ["VGND", "VPWR"])
+tap_1 = logic_module(
+    "sky130_fd_sc_hs__tap_1", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tap_2 = logic_module(
+    "sky130_fd_sc_hs__tap_2", "High Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tapmet1_2 = logic_module(
+    "sky130_fd_sc_hs__tapmet1_2", "High Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvgnd2_1 = logic_module(
+    "sky130_fd_sc_hs__tapvgnd2_1", "High Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvgnd_1 = logic_module(
+    "sky130_fd_sc_hs__tapvgnd_1", "High Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvpwrvgnd_1 = logic_module(
+    "sky130_fd_sc_hs__tapvpwrvgnd_1", "High Speed", ["VGND", "VPWR"]
+)
 xnor2_1 = logic_module(
-    "xnor2_1",
+    "sky130_fd_sc_hs__xnor2_1",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_2 = logic_module(
-    "xnor2_2",
+    "sky130_fd_sc_hs__xnor2_2",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_4 = logic_module(
-    "xnor2_4",
+    "sky130_fd_sc_hs__xnor2_4",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor3_1 = logic_module(
-    "xnor3_1",
+    "sky130_fd_sc_hs__xnor3_1",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_2 = logic_module(
-    "xnor3_2",
+    "sky130_fd_sc_hs__xnor3_2",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_4 = logic_module(
-    "xnor3_4",
+    "sky130_fd_sc_hs__xnor3_4",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_1 = logic_module(
-    "xor2_1",
+    "sky130_fd_sc_hs__xor2_1",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_2 = logic_module(
-    "xor2_2",
+    "sky130_fd_sc_hs__xor2_2",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_4 = logic_module(
-    "xor2_4",
+    "sky130_fd_sc_hs__xor2_4",
     "High Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_1 = logic_module(
-    "xor3_1",
+    "sky130_fd_sc_hs__xor3_1",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_2 = logic_module(
-    "xor3_2",
+    "sky130_fd_sc_hs__xor3_2",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_4 = logic_module(
-    "xor3_4",
+    "sky130_fd_sc_hs__xor3_4",
     "High Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )

--- a/pdks/Sky130/sky130_hdl21/digital_cells/low_leakage.py
+++ b/pdks/Sky130/sky130_hdl21/digital_cells/low_leakage.py
@@ -1,1661 +1,1661 @@
 from ..pdk_data import logic_module
 
 a2bb2o_1 = logic_module(
-    "a2bb2o_1",
+    "sky130_fd_sc_hdll__a2bb2o_1",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_2 = logic_module(
-    "a2bb2o_2",
+    "sky130_fd_sc_hdll__a2bb2o_2",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_4 = logic_module(
-    "a2bb2o_4",
+    "sky130_fd_sc_hdll__a2bb2o_4",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2oi_1 = logic_module(
-    "a2bb2oi_1",
+    "sky130_fd_sc_hdll__a2bb2oi_1",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_2 = logic_module(
-    "a2bb2oi_2",
+    "sky130_fd_sc_hdll__a2bb2oi_2",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_4 = logic_module(
-    "a2bb2oi_4",
+    "sky130_fd_sc_hdll__a2bb2oi_4",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21bo_1 = logic_module(
-    "a21bo_1",
+    "sky130_fd_sc_hdll__a21bo_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_2 = logic_module(
-    "a21bo_2",
+    "sky130_fd_sc_hdll__a21bo_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_4 = logic_module(
-    "a21bo_4",
+    "sky130_fd_sc_hdll__a21bo_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21boi_1 = logic_module(
-    "a21boi_1",
+    "sky130_fd_sc_hdll__a21boi_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_2 = logic_module(
-    "a21boi_2",
+    "sky130_fd_sc_hdll__a21boi_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_4 = logic_module(
-    "a21boi_4",
+    "sky130_fd_sc_hdll__a21boi_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21o_1 = logic_module(
-    "a21o_1",
+    "sky130_fd_sc_hdll__a21o_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_2 = logic_module(
-    "a21o_2",
+    "sky130_fd_sc_hdll__a21o_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_4 = logic_module(
-    "a21o_4",
+    "sky130_fd_sc_hdll__a21o_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_6 = logic_module(
-    "a21o_6",
+    "sky130_fd_sc_hdll__a21o_6",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_8 = logic_module(
-    "a21o_8",
+    "sky130_fd_sc_hdll__a21o_8",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21oi_1 = logic_module(
-    "a21oi_1",
+    "sky130_fd_sc_hdll__a21oi_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_2 = logic_module(
-    "a21oi_2",
+    "sky130_fd_sc_hdll__a21oi_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_4 = logic_module(
-    "a21oi_4",
+    "sky130_fd_sc_hdll__a21oi_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22o_1 = logic_module(
-    "a22o_1",
+    "sky130_fd_sc_hdll__a22o_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_2 = logic_module(
-    "a22o_2",
+    "sky130_fd_sc_hdll__a22o_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_4 = logic_module(
-    "a22o_4",
+    "sky130_fd_sc_hdll__a22o_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22oi_1 = logic_module(
-    "a22oi_1",
+    "sky130_fd_sc_hdll__a22oi_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_2 = logic_module(
-    "a22oi_2",
+    "sky130_fd_sc_hdll__a22oi_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_4 = logic_module(
-    "a22oi_4",
+    "sky130_fd_sc_hdll__a22oi_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31o_1 = logic_module(
-    "a31o_1",
+    "sky130_fd_sc_hdll__a31o_1",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_2 = logic_module(
-    "a31o_2",
+    "sky130_fd_sc_hdll__a31o_2",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_4 = logic_module(
-    "a31o_4",
+    "sky130_fd_sc_hdll__a31o_4",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31oi_1 = logic_module(
-    "a31oi_1",
+    "sky130_fd_sc_hdll__a31oi_1",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_2 = logic_module(
-    "a31oi_2",
+    "sky130_fd_sc_hdll__a31oi_2",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_4 = logic_module(
-    "a31oi_4",
+    "sky130_fd_sc_hdll__a31oi_4",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32o_1 = logic_module(
-    "a32o_1",
+    "sky130_fd_sc_hdll__a32o_1",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_2 = logic_module(
-    "a32o_2",
+    "sky130_fd_sc_hdll__a32o_2",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_4 = logic_module(
-    "a32o_4",
+    "sky130_fd_sc_hdll__a32o_4",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32oi_1 = logic_module(
-    "a32oi_1",
+    "sky130_fd_sc_hdll__a32oi_1",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_2 = logic_module(
-    "a32oi_2",
+    "sky130_fd_sc_hdll__a32oi_2",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_4 = logic_module(
-    "a32oi_4",
+    "sky130_fd_sc_hdll__a32oi_4",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211o_1 = logic_module(
-    "a211o_1",
+    "sky130_fd_sc_hdll__a211o_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_2 = logic_module(
-    "a211o_2",
+    "sky130_fd_sc_hdll__a211o_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_4 = logic_module(
-    "a211o_4",
+    "sky130_fd_sc_hdll__a211o_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211oi_1 = logic_module(
-    "a211oi_1",
+    "sky130_fd_sc_hdll__a211oi_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_2 = logic_module(
-    "a211oi_2",
+    "sky130_fd_sc_hdll__a211oi_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_4 = logic_module(
-    "a211oi_4",
+    "sky130_fd_sc_hdll__a211oi_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_1 = logic_module(
-    "a221oi_1",
+    "sky130_fd_sc_hdll__a221oi_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_2 = logic_module(
-    "a221oi_2",
+    "sky130_fd_sc_hdll__a221oi_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_4 = logic_module(
-    "a221oi_4",
+    "sky130_fd_sc_hdll__a221oi_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a222oi_1 = logic_module(
-    "a222oi_1",
+    "sky130_fd_sc_hdll__a222oi_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 and2_1 = logic_module(
-    "and2_1",
+    "sky130_fd_sc_hdll__and2_1",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_2 = logic_module(
-    "and2_2",
+    "sky130_fd_sc_hdll__and2_2",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_4 = logic_module(
-    "and2_4",
+    "sky130_fd_sc_hdll__and2_4",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_6 = logic_module(
-    "and2_6",
+    "sky130_fd_sc_hdll__and2_6",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_8 = logic_module(
-    "and2_8",
+    "sky130_fd_sc_hdll__and2_8",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_1 = logic_module(
-    "and2b_1",
+    "sky130_fd_sc_hdll__and2b_1",
     "High Density Low Leakage",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_2 = logic_module(
-    "and2b_2",
+    "sky130_fd_sc_hdll__and2b_2",
     "High Density Low Leakage",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_4 = logic_module(
-    "and2b_4",
+    "sky130_fd_sc_hdll__and2b_4",
     "High Density Low Leakage",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_1 = logic_module(
-    "and3_1",
+    "sky130_fd_sc_hdll__and3_1",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_2 = logic_module(
-    "and3_2",
+    "sky130_fd_sc_hdll__and3_2",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_4 = logic_module(
-    "and3_4",
+    "sky130_fd_sc_hdll__and3_4",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_1 = logic_module(
-    "and3b_1",
+    "sky130_fd_sc_hdll__and3b_1",
     "High Density Low Leakage",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_2 = logic_module(
-    "and3b_2",
+    "sky130_fd_sc_hdll__and3b_2",
     "High Density Low Leakage",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_4 = logic_module(
-    "and3b_4",
+    "sky130_fd_sc_hdll__and3b_4",
     "High Density Low Leakage",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_1 = logic_module(
-    "and4_1",
+    "sky130_fd_sc_hdll__and4_1",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_2 = logic_module(
-    "and4_2",
+    "sky130_fd_sc_hdll__and4_2",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_4 = logic_module(
-    "and4_4",
+    "sky130_fd_sc_hdll__and4_4",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_1 = logic_module(
-    "and4b_1",
+    "sky130_fd_sc_hdll__and4b_1",
     "High Density Low Leakage",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_2 = logic_module(
-    "and4b_2",
+    "sky130_fd_sc_hdll__and4b_2",
     "High Density Low Leakage",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_4 = logic_module(
-    "and4b_4",
+    "sky130_fd_sc_hdll__and4b_4",
     "High Density Low Leakage",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_1 = logic_module(
-    "and4bb_1",
+    "sky130_fd_sc_hdll__and4bb_1",
     "High Density Low Leakage",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_2 = logic_module(
-    "and4bb_2",
+    "sky130_fd_sc_hdll__and4bb_2",
     "High Density Low Leakage",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_4 = logic_module(
-    "and4bb_4",
+    "sky130_fd_sc_hdll__and4bb_4",
     "High Density Low Leakage",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_1 = logic_module(
-    "buf_1",
+    "sky130_fd_sc_hdll__buf_1",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_2 = logic_module(
-    "buf_2",
+    "sky130_fd_sc_hdll__buf_2",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_4 = logic_module(
-    "buf_4",
+    "sky130_fd_sc_hdll__buf_4",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_6 = logic_module(
-    "buf_6",
+    "sky130_fd_sc_hdll__buf_6",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_8 = logic_module(
-    "buf_8",
+    "sky130_fd_sc_hdll__buf_8",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_12 = logic_module(
-    "buf_12",
+    "sky130_fd_sc_hdll__buf_12",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_16 = logic_module(
-    "buf_16",
+    "sky130_fd_sc_hdll__buf_16",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_8 = logic_module(
-    "bufbuf_8",
+    "sky130_fd_sc_hdll__bufbuf_8",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_16 = logic_module(
-    "bufbuf_16",
+    "sky130_fd_sc_hdll__bufbuf_16",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufinv_8 = logic_module(
-    "bufinv_8",
+    "sky130_fd_sc_hdll__bufinv_8",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 bufinv_16 = logic_module(
-    "bufinv_16",
+    "sky130_fd_sc_hdll__bufinv_16",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkbuf_1 = logic_module(
-    "clkbuf_1",
+    "sky130_fd_sc_hdll__clkbuf_1",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_2 = logic_module(
-    "clkbuf_2",
+    "sky130_fd_sc_hdll__clkbuf_2",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_4 = logic_module(
-    "clkbuf_4",
+    "sky130_fd_sc_hdll__clkbuf_4",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_6 = logic_module(
-    "clkbuf_6",
+    "sky130_fd_sc_hdll__clkbuf_6",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_8 = logic_module(
-    "clkbuf_8",
+    "sky130_fd_sc_hdll__clkbuf_8",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_12 = logic_module(
-    "clkbuf_12",
+    "sky130_fd_sc_hdll__clkbuf_12",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_16 = logic_module(
-    "clkbuf_16",
+    "sky130_fd_sc_hdll__clkbuf_16",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkinv_1 = logic_module(
-    "clkinv_1",
+    "sky130_fd_sc_hdll__clkinv_1",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_2 = logic_module(
-    "clkinv_2",
+    "sky130_fd_sc_hdll__clkinv_2",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_4 = logic_module(
-    "clkinv_4",
+    "sky130_fd_sc_hdll__clkinv_4",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_8 = logic_module(
-    "clkinv_8",
+    "sky130_fd_sc_hdll__clkinv_8",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_12 = logic_module(
-    "clkinv_12",
+    "sky130_fd_sc_hdll__clkinv_12",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_16 = logic_module(
-    "clkinv_16",
+    "sky130_fd_sc_hdll__clkinv_16",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinvlp_2 = logic_module(
-    "clkinvlp_2",
+    "sky130_fd_sc_hdll__clkinvlp_2",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinvlp_4 = logic_module(
-    "clkinvlp_4",
+    "sky130_fd_sc_hdll__clkinvlp_4",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkmux2_1 = logic_module(
-    "clkmux2_1",
+    "sky130_fd_sc_hdll__clkmux2_1",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkmux2_2 = logic_module(
-    "clkmux2_2",
+    "sky130_fd_sc_hdll__clkmux2_2",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkmux2_4 = logic_module(
-    "clkmux2_4",
+    "sky130_fd_sc_hdll__clkmux2_4",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 conb_1 = logic_module(
-    "conb_1",
+    "sky130_fd_sc_hdll__conb_1",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR", "HI", "LO"],
 )
 decap_3 = logic_module(
-    "decap_3",
+    "sky130_fd_sc_hdll__decap_3",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 decap_4 = logic_module(
-    "decap_4",
+    "sky130_fd_sc_hdll__decap_4",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 decap_6 = logic_module(
-    "decap_6",
+    "sky130_fd_sc_hdll__decap_6",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 decap_8 = logic_module(
-    "decap_8",
+    "sky130_fd_sc_hdll__decap_8",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 decap_12 = logic_module(
-    "decap_12",
+    "sky130_fd_sc_hdll__decap_12",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 dfrtp_1 = logic_module(
-    "dfrtp_1",
+    "sky130_fd_sc_hdll__dfrtp_1",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_2 = logic_module(
-    "dfrtp_2",
+    "sky130_fd_sc_hdll__dfrtp_2",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_4 = logic_module(
-    "dfrtp_4",
+    "sky130_fd_sc_hdll__dfrtp_4",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_1 = logic_module(
-    "dfstp_1",
+    "sky130_fd_sc_hdll__dfstp_1",
     "High Density Low Leakage",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_2 = logic_module(
-    "dfstp_2",
+    "sky130_fd_sc_hdll__dfstp_2",
     "High Density Low Leakage",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_4 = logic_module(
-    "dfstp_4",
+    "sky130_fd_sc_hdll__dfstp_4",
     "High Density Low Leakage",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 diode_2 = logic_module(
-    "diode_2",
+    "sky130_fd_sc_hdll__diode_2",
     "High Density Low Leakage",
     ["DIODE", "VGND", "VNB", "VPB", "VPWR"],
 )
 diode_4 = logic_module(
-    "diode_4",
+    "sky130_fd_sc_hdll__diode_4",
     "High Density Low Leakage",
     ["DIODE", "VGND", "VNB", "VPB", "VPWR"],
 )
 diode_6 = logic_module(
-    "diode_6",
+    "sky130_fd_sc_hdll__diode_6",
     "High Density Low Leakage",
     ["DIODE", "VGND", "VNB", "VPB", "VPWR"],
 )
 diode_8 = logic_module(
-    "diode_8",
+    "sky130_fd_sc_hdll__diode_8",
     "High Density Low Leakage",
     ["DIODE", "VGND", "VNB", "VPB", "VPWR"],
 )
 dlrtn_1 = logic_module(
-    "dlrtn_1",
+    "sky130_fd_sc_hdll__dlrtn_1",
     "High Density Low Leakage",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_2 = logic_module(
-    "dlrtn_2",
+    "sky130_fd_sc_hdll__dlrtn_2",
     "High Density Low Leakage",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_4 = logic_module(
-    "dlrtn_4",
+    "sky130_fd_sc_hdll__dlrtn_4",
     "High Density Low Leakage",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_1 = logic_module(
-    "dlrtp_1",
+    "sky130_fd_sc_hdll__dlrtp_1",
     "High Density Low Leakage",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_2 = logic_module(
-    "dlrtp_2",
+    "sky130_fd_sc_hdll__dlrtp_2",
     "High Density Low Leakage",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_4 = logic_module(
-    "dlrtp_4",
+    "sky130_fd_sc_hdll__dlrtp_4",
     "High Density Low Leakage",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_1 = logic_module(
-    "dlxtn_1",
+    "sky130_fd_sc_hdll__dlxtn_1",
     "High Density Low Leakage",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_2 = logic_module(
-    "dlxtn_2",
+    "sky130_fd_sc_hdll__dlxtn_2",
     "High Density Low Leakage",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_4 = logic_module(
-    "dlxtn_4",
+    "sky130_fd_sc_hdll__dlxtn_4",
     "High Density Low Leakage",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlygate4sd1_1 = logic_module(
-    "dlygate4sd1_1",
+    "sky130_fd_sc_hdll__dlygate4sd1_1",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd2_1 = logic_module(
-    "dlygate4sd2_1",
+    "sky130_fd_sc_hdll__dlygate4sd2_1",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd3_1 = logic_module(
-    "dlygate4sd3_1",
+    "sky130_fd_sc_hdll__dlygate4sd3_1",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 ebufn_1 = logic_module(
-    "ebufn_1",
+    "sky130_fd_sc_hdll__ebufn_1",
     "High Density Low Leakage",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_2 = logic_module(
-    "ebufn_2",
+    "sky130_fd_sc_hdll__ebufn_2",
     "High Density Low Leakage",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_4 = logic_module(
-    "ebufn_4",
+    "sky130_fd_sc_hdll__ebufn_4",
     "High Density Low Leakage",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_8 = logic_module(
-    "ebufn_8",
+    "sky130_fd_sc_hdll__ebufn_8",
     "High Density Low Leakage",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_1 = logic_module(
-    "einvn_1",
+    "sky130_fd_sc_hdll__einvn_1",
     "High Density Low Leakage",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_2 = logic_module(
-    "einvn_2",
+    "sky130_fd_sc_hdll__einvn_2",
     "High Density Low Leakage",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_4 = logic_module(
-    "einvn_4",
+    "sky130_fd_sc_hdll__einvn_4",
     "High Density Low Leakage",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_8 = logic_module(
-    "einvn_8",
+    "sky130_fd_sc_hdll__einvn_8",
     "High Density Low Leakage",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_1 = logic_module(
-    "einvp_1",
+    "sky130_fd_sc_hdll__einvp_1",
     "High Density Low Leakage",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_2 = logic_module(
-    "einvp_2",
+    "sky130_fd_sc_hdll__einvp_2",
     "High Density Low Leakage",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_4 = logic_module(
-    "einvp_4",
+    "sky130_fd_sc_hdll__einvp_4",
     "High Density Low Leakage",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_8 = logic_module(
-    "einvp_8",
+    "sky130_fd_sc_hdll__einvp_8",
     "High Density Low Leakage",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 fill_1 = logic_module(
-    "fill_1",
+    "sky130_fd_sc_hdll__fill_1",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 fill_2 = logic_module(
-    "fill_2",
+    "sky130_fd_sc_hdll__fill_2",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 fill_4 = logic_module(
-    "fill_4",
+    "sky130_fd_sc_hdll__fill_4",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 fill_8 = logic_module(
-    "fill_8",
+    "sky130_fd_sc_hdll__fill_8",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 inputiso0n_1 = logic_module(
-    "inputiso0n_1",
+    "sky130_fd_sc_hdll__inputiso0n_1",
     "High Density Low Leakage",
     ["A", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 inputiso0p_1 = logic_module(
-    "inputiso0p_1",
+    "sky130_fd_sc_hdll__inputiso0p_1",
     "High Density Low Leakage",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 inputiso1n_1 = logic_module(
-    "inputiso1n_1",
+    "sky130_fd_sc_hdll__inputiso1n_1",
     "High Density Low Leakage",
     ["A", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 inputiso1p_1 = logic_module(
-    "inputiso1p_1",
+    "sky130_fd_sc_hdll__inputiso1p_1",
     "High Density Low Leakage",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 inv_1 = logic_module(
-    "inv_1",
+    "sky130_fd_sc_hdll__inv_1",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_2 = logic_module(
-    "inv_2",
+    "sky130_fd_sc_hdll__inv_2",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_4 = logic_module(
-    "inv_4",
+    "sky130_fd_sc_hdll__inv_4",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_6 = logic_module(
-    "inv_6",
+    "sky130_fd_sc_hdll__inv_6",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_8 = logic_module(
-    "inv_8",
+    "sky130_fd_sc_hdll__inv_8",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_12 = logic_module(
-    "inv_12",
+    "sky130_fd_sc_hdll__inv_12",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_16 = logic_module(
-    "inv_16",
+    "sky130_fd_sc_hdll__inv_16",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 isobufsrc_1 = logic_module(
-    "isobufsrc_1",
+    "sky130_fd_sc_hdll__isobufsrc_1",
     "High Density Low Leakage",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 isobufsrc_2 = logic_module(
-    "isobufsrc_2",
+    "sky130_fd_sc_hdll__isobufsrc_2",
     "High Density Low Leakage",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 isobufsrc_4 = logic_module(
-    "isobufsrc_4",
+    "sky130_fd_sc_hdll__isobufsrc_4",
     "High Density Low Leakage",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 isobufsrc_8 = logic_module(
-    "isobufsrc_8",
+    "sky130_fd_sc_hdll__isobufsrc_8",
     "High Density Low Leakage",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 isobufsrc_16 = logic_module(
-    "isobufsrc_16",
+    "sky130_fd_sc_hdll__isobufsrc_16",
     "High Density Low Leakage",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_1 = logic_module(
-    "mux2_1",
+    "sky130_fd_sc_hdll__mux2_1",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_2 = logic_module(
-    "mux2_2",
+    "sky130_fd_sc_hdll__mux2_2",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_4 = logic_module(
-    "mux2_4",
+    "sky130_fd_sc_hdll__mux2_4",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_8 = logic_module(
-    "mux2_8",
+    "sky130_fd_sc_hdll__mux2_8",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_12 = logic_module(
-    "mux2_12",
+    "sky130_fd_sc_hdll__mux2_12",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_16 = logic_module(
-    "mux2_16",
+    "sky130_fd_sc_hdll__mux2_16",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2i_1 = logic_module(
-    "mux2i_1",
+    "sky130_fd_sc_hdll__mux2i_1",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_2 = logic_module(
-    "mux2i_2",
+    "sky130_fd_sc_hdll__mux2i_2",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_4 = logic_module(
-    "mux2i_4",
+    "sky130_fd_sc_hdll__mux2i_4",
     "High Density Low Leakage",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 muxb4to1_1 = logic_module(
-    "muxb4to1_1",
+    "sky130_fd_sc_hdll__muxb4to1_1",
     "High Density Low Leakage",
     ["D[3]", "D[2]", "D[1]", "D[0]", "S[3]", "S[2]", "S[1]", "S[0]", "VGND"],
 )
 muxb4to1_2 = logic_module(
-    "muxb4to1_2",
+    "sky130_fd_sc_hdll__muxb4to1_2",
     "High Density Low Leakage",
     ["D[3]", "D[2]", "D[1]", "D[0]", "S[3]", "S[2]", "S[1]", "S[0]", "VGND"],
 )
 muxb4to1_4 = logic_module(
-    "muxb4to1_4",
+    "sky130_fd_sc_hdll__muxb4to1_4",
     "High Density Low Leakage",
     ["D[3]", "D[2]", "D[1]", "D[0]", "S[3]", "S[2]", "S[1]", "S[0]", "VGND"],
 )
 muxb8to1_1 = logic_module(
-    "muxb8to1_1",
+    "sky130_fd_sc_hdll__muxb8to1_1",
     "High Density Low Leakage",
     ["D[7]", "D[6]", "D[5]", "D[4]", "D[3]", "D[2]", "D[1]", "D[0]", "S[7]"],
 )
 muxb8to1_2 = logic_module(
-    "muxb8to1_2",
+    "sky130_fd_sc_hdll__muxb8to1_2",
     "High Density Low Leakage",
     ["D[7]", "D[6]", "D[5]", "D[4]", "D[3]", "D[2]", "D[1]", "D[0]", "S[7]"],
 )
 muxb8to1_4 = logic_module(
-    "muxb8to1_4",
+    "sky130_fd_sc_hdll__muxb8to1_4",
     "High Density Low Leakage",
     ["D[7]", "D[6]", "D[5]", "D[4]", "D[3]", "D[2]", "D[1]", "D[0]", "S[7]"],
 )
 muxb16to1_1 = logic_module(
-    "muxb16to1_1",
+    "sky130_fd_sc_hdll__muxb16to1_1",
     "High Density Low Leakage",
     ["D[15]", "D[14]", "D[13]", "D[12]", "D[11]", "D[10]", "D[9]", "D[8]"],
 )
 muxb16to1_2 = logic_module(
-    "muxb16to1_2",
+    "sky130_fd_sc_hdll__muxb16to1_2",
     "High Density Low Leakage",
     ["D[15]", "D[14]", "D[13]", "D[12]", "D[11]", "D[10]", "D[9]", "D[8]"],
 )
 muxb16to1_4 = logic_module(
-    "muxb16to1_4",
+    "sky130_fd_sc_hdll__muxb16to1_4",
     "High Density Low Leakage",
     ["D[15]", "D[14]", "D[13]", "D[12]", "D[11]", "D[10]", "D[9]", "D[8]"],
 )
 nand2_1 = logic_module(
-    "nand2_1",
+    "sky130_fd_sc_hdll__nand2_1",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_2 = logic_module(
-    "nand2_2",
+    "sky130_fd_sc_hdll__nand2_2",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_4 = logic_module(
-    "nand2_4",
+    "sky130_fd_sc_hdll__nand2_4",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_6 = logic_module(
-    "nand2_6",
+    "sky130_fd_sc_hdll__nand2_6",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_8 = logic_module(
-    "nand2_8",
+    "sky130_fd_sc_hdll__nand2_8",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_12 = logic_module(
-    "nand2_12",
+    "sky130_fd_sc_hdll__nand2_12",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_16 = logic_module(
-    "nand2_16",
+    "sky130_fd_sc_hdll__nand2_16",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_1 = logic_module(
-    "nand2b_1",
+    "sky130_fd_sc_hdll__nand2b_1",
     "High Density Low Leakage",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_2 = logic_module(
-    "nand2b_2",
+    "sky130_fd_sc_hdll__nand2b_2",
     "High Density Low Leakage",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_4 = logic_module(
-    "nand2b_4",
+    "sky130_fd_sc_hdll__nand2b_4",
     "High Density Low Leakage",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_1 = logic_module(
-    "nand3_1",
+    "sky130_fd_sc_hdll__nand3_1",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_2 = logic_module(
-    "nand3_2",
+    "sky130_fd_sc_hdll__nand3_2",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_4 = logic_module(
-    "nand3_4",
+    "sky130_fd_sc_hdll__nand3_4",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_1 = logic_module(
-    "nand3b_1",
+    "sky130_fd_sc_hdll__nand3b_1",
     "High Density Low Leakage",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_2 = logic_module(
-    "nand3b_2",
+    "sky130_fd_sc_hdll__nand3b_2",
     "High Density Low Leakage",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_4 = logic_module(
-    "nand3b_4",
+    "sky130_fd_sc_hdll__nand3b_4",
     "High Density Low Leakage",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_1 = logic_module(
-    "nand4_1",
+    "sky130_fd_sc_hdll__nand4_1",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_2 = logic_module(
-    "nand4_2",
+    "sky130_fd_sc_hdll__nand4_2",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_4 = logic_module(
-    "nand4_4",
+    "sky130_fd_sc_hdll__nand4_4",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_1 = logic_module(
-    "nand4b_1",
+    "sky130_fd_sc_hdll__nand4b_1",
     "High Density Low Leakage",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_2 = logic_module(
-    "nand4b_2",
+    "sky130_fd_sc_hdll__nand4b_2",
     "High Density Low Leakage",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_4 = logic_module(
-    "nand4b_4",
+    "sky130_fd_sc_hdll__nand4b_4",
     "High Density Low Leakage",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_1 = logic_module(
-    "nand4bb_1",
+    "sky130_fd_sc_hdll__nand4bb_1",
     "High Density Low Leakage",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_2 = logic_module(
-    "nand4bb_2",
+    "sky130_fd_sc_hdll__nand4bb_2",
     "High Density Low Leakage",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_4 = logic_module(
-    "nand4bb_4",
+    "sky130_fd_sc_hdll__nand4bb_4",
     "High Density Low Leakage",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_1 = logic_module(
-    "nor2_1",
+    "sky130_fd_sc_hdll__nor2_1",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_2 = logic_module(
-    "nor2_2",
+    "sky130_fd_sc_hdll__nor2_2",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_4 = logic_module(
-    "nor2_4",
+    "sky130_fd_sc_hdll__nor2_4",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_8 = logic_module(
-    "nor2_8",
+    "sky130_fd_sc_hdll__nor2_8",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_1 = logic_module(
-    "nor2b_1",
+    "sky130_fd_sc_hdll__nor2b_1",
     "High Density Low Leakage",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_2 = logic_module(
-    "nor2b_2",
+    "sky130_fd_sc_hdll__nor2b_2",
     "High Density Low Leakage",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_4 = logic_module(
-    "nor2b_4",
+    "sky130_fd_sc_hdll__nor2b_4",
     "High Density Low Leakage",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_1 = logic_module(
-    "nor3_1",
+    "sky130_fd_sc_hdll__nor3_1",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_2 = logic_module(
-    "nor3_2",
+    "sky130_fd_sc_hdll__nor3_2",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_4 = logic_module(
-    "nor3_4",
+    "sky130_fd_sc_hdll__nor3_4",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_1 = logic_module(
-    "nor3b_1",
+    "sky130_fd_sc_hdll__nor3b_1",
     "High Density Low Leakage",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_2 = logic_module(
-    "nor3b_2",
+    "sky130_fd_sc_hdll__nor3b_2",
     "High Density Low Leakage",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_4 = logic_module(
-    "nor3b_4",
+    "sky130_fd_sc_hdll__nor3b_4",
     "High Density Low Leakage",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_1 = logic_module(
-    "nor4_1",
+    "sky130_fd_sc_hdll__nor4_1",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_2 = logic_module(
-    "nor4_2",
+    "sky130_fd_sc_hdll__nor4_2",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_4 = logic_module(
-    "nor4_4",
+    "sky130_fd_sc_hdll__nor4_4",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_6 = logic_module(
-    "nor4_6",
+    "sky130_fd_sc_hdll__nor4_6",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_8 = logic_module(
-    "nor4_8",
+    "sky130_fd_sc_hdll__nor4_8",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_1 = logic_module(
-    "nor4b_1",
+    "sky130_fd_sc_hdll__nor4b_1",
     "High Density Low Leakage",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_2 = logic_module(
-    "nor4b_2",
+    "sky130_fd_sc_hdll__nor4b_2",
     "High Density Low Leakage",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_4 = logic_module(
-    "nor4b_4",
+    "sky130_fd_sc_hdll__nor4b_4",
     "High Density Low Leakage",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_1 = logic_module(
-    "nor4bb_1",
+    "sky130_fd_sc_hdll__nor4bb_1",
     "High Density Low Leakage",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_2 = logic_module(
-    "nor4bb_2",
+    "sky130_fd_sc_hdll__nor4bb_2",
     "High Density Low Leakage",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_4 = logic_module(
-    "nor4bb_4",
+    "sky130_fd_sc_hdll__nor4bb_4",
     "High Density Low Leakage",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2a_1 = logic_module(
-    "o2bb2a_1",
+    "sky130_fd_sc_hdll__o2bb2a_1",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_2 = logic_module(
-    "o2bb2a_2",
+    "sky130_fd_sc_hdll__o2bb2a_2",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_4 = logic_module(
-    "o2bb2a_4",
+    "sky130_fd_sc_hdll__o2bb2a_4",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2ai_1 = logic_module(
-    "o2bb2ai_1",
+    "sky130_fd_sc_hdll__o2bb2ai_1",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_2 = logic_module(
-    "o2bb2ai_2",
+    "sky130_fd_sc_hdll__o2bb2ai_2",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_4 = logic_module(
-    "o2bb2ai_4",
+    "sky130_fd_sc_hdll__o2bb2ai_4",
     "High Density Low Leakage",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21a_1 = logic_module(
-    "o21a_1",
+    "sky130_fd_sc_hdll__o21a_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_2 = logic_module(
-    "o21a_2",
+    "sky130_fd_sc_hdll__o21a_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_4 = logic_module(
-    "o21a_4",
+    "sky130_fd_sc_hdll__o21a_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ai_1 = logic_module(
-    "o21ai_1",
+    "sky130_fd_sc_hdll__o21ai_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_2 = logic_module(
-    "o21ai_2",
+    "sky130_fd_sc_hdll__o21ai_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_4 = logic_module(
-    "o21ai_4",
+    "sky130_fd_sc_hdll__o21ai_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ba_1 = logic_module(
-    "o21ba_1",
+    "sky130_fd_sc_hdll__o21ba_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_2 = logic_module(
-    "o21ba_2",
+    "sky130_fd_sc_hdll__o21ba_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_4 = logic_module(
-    "o21ba_4",
+    "sky130_fd_sc_hdll__o21ba_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21bai_1 = logic_module(
-    "o21bai_1",
+    "sky130_fd_sc_hdll__o21bai_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_2 = logic_module(
-    "o21bai_2",
+    "sky130_fd_sc_hdll__o21bai_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_4 = logic_module(
-    "o21bai_4",
+    "sky130_fd_sc_hdll__o21bai_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22a_1 = logic_module(
-    "o22a_1",
+    "sky130_fd_sc_hdll__o22a_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_2 = logic_module(
-    "o22a_2",
+    "sky130_fd_sc_hdll__o22a_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_4 = logic_module(
-    "o22a_4",
+    "sky130_fd_sc_hdll__o22a_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22ai_1 = logic_module(
-    "o22ai_1",
+    "sky130_fd_sc_hdll__o22ai_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_2 = logic_module(
-    "o22ai_2",
+    "sky130_fd_sc_hdll__o22ai_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_4 = logic_module(
-    "o22ai_4",
+    "sky130_fd_sc_hdll__o22ai_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_1 = logic_module(
-    "o31ai_1",
+    "sky130_fd_sc_hdll__o31ai_1",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_2 = logic_module(
-    "o31ai_2",
+    "sky130_fd_sc_hdll__o31ai_2",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_4 = logic_module(
-    "o31ai_4",
+    "sky130_fd_sc_hdll__o31ai_4",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_1 = logic_module(
-    "o32ai_1",
+    "sky130_fd_sc_hdll__o32ai_1",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_2 = logic_module(
-    "o32ai_2",
+    "sky130_fd_sc_hdll__o32ai_2",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_4 = logic_module(
-    "o32ai_4",
+    "sky130_fd_sc_hdll__o32ai_4",
     "High Density Low Leakage",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211a_1 = logic_module(
-    "o211a_1",
+    "sky130_fd_sc_hdll__o211a_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_2 = logic_module(
-    "o211a_2",
+    "sky130_fd_sc_hdll__o211a_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_4 = logic_module(
-    "o211a_4",
+    "sky130_fd_sc_hdll__o211a_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211ai_1 = logic_module(
-    "o211ai_1",
+    "sky130_fd_sc_hdll__o211ai_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_2 = logic_module(
-    "o211ai_2",
+    "sky130_fd_sc_hdll__o211ai_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_4 = logic_module(
-    "o211ai_4",
+    "sky130_fd_sc_hdll__o211ai_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221a_1 = logic_module(
-    "o221a_1",
+    "sky130_fd_sc_hdll__o221a_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_2 = logic_module(
-    "o221a_2",
+    "sky130_fd_sc_hdll__o221a_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_4 = logic_module(
-    "o221a_4",
+    "sky130_fd_sc_hdll__o221a_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221ai_1 = logic_module(
-    "o221ai_1",
+    "sky130_fd_sc_hdll__o221ai_1",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_2 = logic_module(
-    "o221ai_2",
+    "sky130_fd_sc_hdll__o221ai_2",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_4 = logic_module(
-    "o221ai_4",
+    "sky130_fd_sc_hdll__o221ai_4",
     "High Density Low Leakage",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 or2_1 = logic_module(
-    "or2_1",
+    "sky130_fd_sc_hdll__or2_1",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_2 = logic_module(
-    "or2_2",
+    "sky130_fd_sc_hdll__or2_2",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_4 = logic_module(
-    "or2_4",
+    "sky130_fd_sc_hdll__or2_4",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_6 = logic_module(
-    "or2_6",
+    "sky130_fd_sc_hdll__or2_6",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_8 = logic_module(
-    "or2_8",
+    "sky130_fd_sc_hdll__or2_8",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_1 = logic_module(
-    "or2b_1",
+    "sky130_fd_sc_hdll__or2b_1",
     "High Density Low Leakage",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_2 = logic_module(
-    "or2b_2",
+    "sky130_fd_sc_hdll__or2b_2",
     "High Density Low Leakage",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_4 = logic_module(
-    "or2b_4",
+    "sky130_fd_sc_hdll__or2b_4",
     "High Density Low Leakage",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_1 = logic_module(
-    "or3_1",
+    "sky130_fd_sc_hdll__or3_1",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_2 = logic_module(
-    "or3_2",
+    "sky130_fd_sc_hdll__or3_2",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_4 = logic_module(
-    "or3_4",
+    "sky130_fd_sc_hdll__or3_4",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_1 = logic_module(
-    "or3b_1",
+    "sky130_fd_sc_hdll__or3b_1",
     "High Density Low Leakage",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_2 = logic_module(
-    "or3b_2",
+    "sky130_fd_sc_hdll__or3b_2",
     "High Density Low Leakage",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_4 = logic_module(
-    "or3b_4",
+    "sky130_fd_sc_hdll__or3b_4",
     "High Density Low Leakage",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_1 = logic_module(
-    "or4_1",
+    "sky130_fd_sc_hdll__or4_1",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_2 = logic_module(
-    "or4_2",
+    "sky130_fd_sc_hdll__or4_2",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_4 = logic_module(
-    "or4_4",
+    "sky130_fd_sc_hdll__or4_4",
     "High Density Low Leakage",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_1 = logic_module(
-    "or4b_1",
+    "sky130_fd_sc_hdll__or4b_1",
     "High Density Low Leakage",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_2 = logic_module(
-    "or4b_2",
+    "sky130_fd_sc_hdll__or4b_2",
     "High Density Low Leakage",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_4 = logic_module(
-    "or4b_4",
+    "sky130_fd_sc_hdll__or4b_4",
     "High Density Low Leakage",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_1 = logic_module(
-    "or4bb_1",
+    "sky130_fd_sc_hdll__or4bb_1",
     "High Density Low Leakage",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_2 = logic_module(
-    "or4bb_2",
+    "sky130_fd_sc_hdll__or4bb_2",
     "High Density Low Leakage",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_4 = logic_module(
-    "or4bb_4",
+    "sky130_fd_sc_hdll__or4bb_4",
     "High Density Low Leakage",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 probe_p_8 = logic_module(
-    "probe_p_8",
+    "sky130_fd_sc_hdll__probe_p_8",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 probec_p_8 = logic_module(
-    "probec_p_8",
+    "sky130_fd_sc_hdll__probec_p_8",
     "High Density Low Leakage",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 sdfbbp_1 = logic_module(
-    "sdfbbp_1",
+    "sky130_fd_sc_hdll__sdfbbp_1",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfrbp_1 = logic_module(
-    "sdfrbp_1",
+    "sky130_fd_sc_hdll__sdfrbp_1",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrbp_2 = logic_module(
-    "sdfrbp_2",
+    "sky130_fd_sc_hdll__sdfrbp_2",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrtn_1 = logic_module(
-    "sdfrtn_1",
+    "sky130_fd_sc_hdll__sdfrtn_1",
     "High Density Low Leakage",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_1 = logic_module(
-    "sdfrtp_1",
+    "sky130_fd_sc_hdll__sdfrtp_1",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_2 = logic_module(
-    "sdfrtp_2",
+    "sky130_fd_sc_hdll__sdfrtp_2",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_4 = logic_module(
-    "sdfrtp_4",
+    "sky130_fd_sc_hdll__sdfrtp_4",
     "High Density Low Leakage",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfsbp_1 = logic_module(
-    "sdfsbp_1",
+    "sky130_fd_sc_hdll__sdfsbp_1",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfsbp_2 = logic_module(
-    "sdfsbp_2",
+    "sky130_fd_sc_hdll__sdfsbp_2",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfstp_1 = logic_module(
-    "sdfstp_1",
+    "sky130_fd_sc_hdll__sdfstp_1",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_2 = logic_module(
-    "sdfstp_2",
+    "sky130_fd_sc_hdll__sdfstp_2",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_4 = logic_module(
-    "sdfstp_4",
+    "sky130_fd_sc_hdll__sdfstp_4",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxbp_1 = logic_module(
-    "sdfxbp_1",
+    "sky130_fd_sc_hdll__sdfxbp_1",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxbp_2 = logic_module(
-    "sdfxbp_2",
+    "sky130_fd_sc_hdll__sdfxbp_2",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxtp_1 = logic_module(
-    "sdfxtp_1",
+    "sky130_fd_sc_hdll__sdfxtp_1",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_2 = logic_module(
-    "sdfxtp_2",
+    "sky130_fd_sc_hdll__sdfxtp_2",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_4 = logic_module(
-    "sdfxtp_4",
+    "sky130_fd_sc_hdll__sdfxtp_4",
     "High Density Low Leakage",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdlclkp_1 = logic_module(
-    "sdlclkp_1",
+    "sky130_fd_sc_hdll__sdlclkp_1",
     "High Density Low Leakage",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_2 = logic_module(
-    "sdlclkp_2",
+    "sky130_fd_sc_hdll__sdlclkp_2",
     "High Density Low Leakage",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_4 = logic_module(
-    "sdlclkp_4",
+    "sky130_fd_sc_hdll__sdlclkp_4",
     "High Density Low Leakage",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sedfxbp_1 = logic_module(
-    "sedfxbp_1",
+    "sky130_fd_sc_hdll__sedfxbp_1",
     "High Density Low Leakage",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxbp_2 = logic_module(
-    "sedfxbp_2",
+    "sky130_fd_sc_hdll__sedfxbp_2",
     "High Density Low Leakage",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 tap = logic_module("tap", "High Density Low Leakage", ["VGND", "VPWR"])
 tap_1 = logic_module(
-    "tap_1",
+    "sky130_fd_sc_hdll__tap_1",
     "High Density Low Leakage",
     ["VGND", "VNB", "VPB", "VPWR"],
 )
 tapvgnd2_1 = logic_module(
-    "tapvgnd2_1",
+    "sky130_fd_sc_hdll__tapvgnd2_1",
     "High Density Low Leakage",
     ["VGND", "VPB", "VPWR"],
 )
 tapvgnd_1 = logic_module(
-    "tapvgnd_1",
+    "sky130_fd_sc_hdll__tapvgnd_1",
     "High Density Low Leakage",
     ["VGND", "VPB", "VPWR"],
 )
 tapvpwrvgnd_1 = logic_module(
-    "tapvpwrvgnd_1", "High Density Low Leakage", ["VGND", "VPWR"]
+    "sky130_fd_sc_hdll__tapvpwrvgnd_1", "High Density Low Leakage", ["VGND", "VPWR"]
 )
 xnor2_1 = logic_module(
-    "xnor2_1",
+    "sky130_fd_sc_hdll__xnor2_1",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_2 = logic_module(
-    "xnor2_2",
+    "sky130_fd_sc_hdll__xnor2_2",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_4 = logic_module(
-    "xnor2_4",
+    "sky130_fd_sc_hdll__xnor2_4",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor3_1 = logic_module(
-    "xnor3_1",
+    "sky130_fd_sc_hdll__xnor3_1",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_2 = logic_module(
-    "xnor3_2",
+    "sky130_fd_sc_hdll__xnor3_2",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_4 = logic_module(
-    "xnor3_4",
+    "sky130_fd_sc_hdll__xnor3_4",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_1 = logic_module(
-    "xor2_1",
+    "sky130_fd_sc_hdll__xor2_1",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_2 = logic_module(
-    "xor2_2",
+    "sky130_fd_sc_hdll__xor2_2",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_4 = logic_module(
-    "xor2_4",
+    "sky130_fd_sc_hdll__xor2_4",
     "High Density Low Leakage",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_1 = logic_module(
-    "xor3_1",
+    "sky130_fd_sc_hdll__xor3_1",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_2 = logic_module(
-    "xor3_2",
+    "sky130_fd_sc_hdll__xor3_2",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_4 = logic_module(
-    "xor3_4",
+    "sky130_fd_sc_hdll__xor3_4",
     "High Density Low Leakage",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )

--- a/pdks/Sky130/sky130_hdl21/digital_cells/low_power.py
+++ b/pdks/Sky130/sky130_hdl21/digital_cells/low_power.py
@@ -1,3570 +1,3636 @@
 from ..pdk_data import logic_module
 
 a2bb2o_0 = logic_module(
-    "a2bb2o_0",
+    "sky130_fd_sc_lp__a2bb2o_0",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_1 = logic_module(
-    "a2bb2o_1",
+    "sky130_fd_sc_lp__a2bb2o_1",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_2 = logic_module(
-    "a2bb2o_2",
+    "sky130_fd_sc_lp__a2bb2o_2",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_4 = logic_module(
-    "a2bb2o_4",
+    "sky130_fd_sc_lp__a2bb2o_4",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_lp = logic_module(
-    "a2bb2o_lp",
+    "sky130_fd_sc_lp__a2bb2o_lp",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_m = logic_module(
-    "a2bb2o_m",
+    "sky130_fd_sc_lp__a2bb2o_m",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2oi_0 = logic_module(
-    "a2bb2oi_0",
+    "sky130_fd_sc_lp__a2bb2oi_0",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_1 = logic_module(
-    "a2bb2oi_1",
+    "sky130_fd_sc_lp__a2bb2oi_1",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_2 = logic_module(
-    "a2bb2oi_2",
+    "sky130_fd_sc_lp__a2bb2oi_2",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_4 = logic_module(
-    "a2bb2oi_4",
+    "sky130_fd_sc_lp__a2bb2oi_4",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_lp = logic_module(
-    "a2bb2oi_lp",
+    "sky130_fd_sc_lp__a2bb2oi_lp",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_m = logic_module(
-    "a2bb2oi_m",
+    "sky130_fd_sc_lp__a2bb2oi_m",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21bo_0 = logic_module(
-    "a21bo_0",
+    "sky130_fd_sc_lp__a21bo_0",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_1 = logic_module(
-    "a21bo_1",
+    "sky130_fd_sc_lp__a21bo_1",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_2 = logic_module(
-    "a21bo_2",
+    "sky130_fd_sc_lp__a21bo_2",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_4 = logic_module(
-    "a21bo_4",
+    "sky130_fd_sc_lp__a21bo_4",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_lp = logic_module(
-    "a21bo_lp",
+    "sky130_fd_sc_lp__a21bo_lp",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_m = logic_module(
-    "a21bo_m",
+    "sky130_fd_sc_lp__a21bo_m",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21boi_0 = logic_module(
-    "a21boi_0",
+    "sky130_fd_sc_lp__a21boi_0",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_1 = logic_module(
-    "a21boi_1",
+    "sky130_fd_sc_lp__a21boi_1",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_2 = logic_module(
-    "a21boi_2",
+    "sky130_fd_sc_lp__a21boi_2",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_4 = logic_module(
-    "a21boi_4",
+    "sky130_fd_sc_lp__a21boi_4",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_lp = logic_module(
-    "a21boi_lp",
+    "sky130_fd_sc_lp__a21boi_lp",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_m = logic_module(
-    "a21boi_m",
+    "sky130_fd_sc_lp__a21boi_m",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21o_0 = logic_module(
-    "a21o_0",
+    "sky130_fd_sc_lp__a21o_0",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_1 = logic_module(
-    "a21o_1",
+    "sky130_fd_sc_lp__a21o_1",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_2 = logic_module(
-    "a21o_2",
+    "sky130_fd_sc_lp__a21o_2",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_4 = logic_module(
-    "a21o_4",
+    "sky130_fd_sc_lp__a21o_4",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_lp = logic_module(
-    "a21o_lp",
+    "sky130_fd_sc_lp__a21o_lp",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_m = logic_module(
-    "a21o_m",
+    "sky130_fd_sc_lp__a21o_m",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21oi_0 = logic_module(
-    "a21oi_0",
+    "sky130_fd_sc_lp__a21oi_0",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_1 = logic_module(
-    "a21oi_1",
+    "sky130_fd_sc_lp__a21oi_1",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_2 = logic_module(
-    "a21oi_2",
+    "sky130_fd_sc_lp__a21oi_2",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_4 = logic_module(
-    "a21oi_4",
+    "sky130_fd_sc_lp__a21oi_4",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_lp = logic_module(
-    "a21oi_lp",
+    "sky130_fd_sc_lp__a21oi_lp",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_m = logic_module(
-    "a21oi_m",
+    "sky130_fd_sc_lp__a21oi_m",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22o_0 = logic_module(
-    "a22o_0",
+    "sky130_fd_sc_lp__a22o_0",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_1 = logic_module(
-    "a22o_1",
+    "sky130_fd_sc_lp__a22o_1",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_2 = logic_module(
-    "a22o_2",
+    "sky130_fd_sc_lp__a22o_2",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_4 = logic_module(
-    "a22o_4",
+    "sky130_fd_sc_lp__a22o_4",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_lp = logic_module(
-    "a22o_lp",
+    "sky130_fd_sc_lp__a22o_lp",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_m = logic_module(
-    "a22o_m",
+    "sky130_fd_sc_lp__a22o_m",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22oi_0 = logic_module(
-    "a22oi_0",
+    "sky130_fd_sc_lp__a22oi_0",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_1 = logic_module(
-    "a22oi_1",
+    "sky130_fd_sc_lp__a22oi_1",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_2 = logic_module(
-    "a22oi_2",
+    "sky130_fd_sc_lp__a22oi_2",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_4 = logic_module(
-    "a22oi_4",
+    "sky130_fd_sc_lp__a22oi_4",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_lp = logic_module(
-    "a22oi_lp",
+    "sky130_fd_sc_lp__a22oi_lp",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_m = logic_module(
-    "a22oi_m",
+    "sky130_fd_sc_lp__a22oi_m",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31o_0 = logic_module(
-    "a31o_0",
+    "sky130_fd_sc_lp__a31o_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_1 = logic_module(
-    "a31o_1",
+    "sky130_fd_sc_lp__a31o_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_2 = logic_module(
-    "a31o_2",
+    "sky130_fd_sc_lp__a31o_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_4 = logic_module(
-    "a31o_4",
+    "sky130_fd_sc_lp__a31o_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_lp = logic_module(
-    "a31o_lp",
+    "sky130_fd_sc_lp__a31o_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_m = logic_module(
-    "a31o_m",
+    "sky130_fd_sc_lp__a31o_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31oi_0 = logic_module(
-    "a31oi_0",
+    "sky130_fd_sc_lp__a31oi_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_1 = logic_module(
-    "a31oi_1",
+    "sky130_fd_sc_lp__a31oi_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_2 = logic_module(
-    "a31oi_2",
+    "sky130_fd_sc_lp__a31oi_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_4 = logic_module(
-    "a31oi_4",
+    "sky130_fd_sc_lp__a31oi_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_lp = logic_module(
-    "a31oi_lp",
+    "sky130_fd_sc_lp__a31oi_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_m = logic_module(
-    "a31oi_m",
+    "sky130_fd_sc_lp__a31oi_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32o_0 = logic_module(
-    "a32o_0",
+    "sky130_fd_sc_lp__a32o_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_1 = logic_module(
-    "a32o_1",
+    "sky130_fd_sc_lp__a32o_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_2 = logic_module(
-    "a32o_2",
+    "sky130_fd_sc_lp__a32o_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_4 = logic_module(
-    "a32o_4",
+    "sky130_fd_sc_lp__a32o_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_lp = logic_module(
-    "a32o_lp",
+    "sky130_fd_sc_lp__a32o_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_m = logic_module(
-    "a32o_m",
+    "sky130_fd_sc_lp__a32o_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32oi_0 = logic_module(
-    "a32oi_0",
+    "sky130_fd_sc_lp__a32oi_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_1 = logic_module(
-    "a32oi_1",
+    "sky130_fd_sc_lp__a32oi_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_2 = logic_module(
-    "a32oi_2",
+    "sky130_fd_sc_lp__a32oi_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_4 = logic_module(
-    "a32oi_4",
+    "sky130_fd_sc_lp__a32oi_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_lp = logic_module(
-    "a32oi_lp",
+    "sky130_fd_sc_lp__a32oi_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_m = logic_module(
-    "a32oi_m",
+    "sky130_fd_sc_lp__a32oi_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41o_0 = logic_module(
-    "a41o_0",
+    "sky130_fd_sc_lp__a41o_0",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_1 = logic_module(
-    "a41o_1",
+    "sky130_fd_sc_lp__a41o_1",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_2 = logic_module(
-    "a41o_2",
+    "sky130_fd_sc_lp__a41o_2",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_4 = logic_module(
-    "a41o_4",
+    "sky130_fd_sc_lp__a41o_4",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_lp = logic_module(
-    "a41o_lp",
+    "sky130_fd_sc_lp__a41o_lp",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_m = logic_module(
-    "a41o_m",
+    "sky130_fd_sc_lp__a41o_m",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41oi_0 = logic_module(
-    "a41oi_0",
+    "sky130_fd_sc_lp__a41oi_0",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_1 = logic_module(
-    "a41oi_1",
+    "sky130_fd_sc_lp__a41oi_1",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_2 = logic_module(
-    "a41oi_2",
+    "sky130_fd_sc_lp__a41oi_2",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_4 = logic_module(
-    "a41oi_4",
+    "sky130_fd_sc_lp__a41oi_4",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_lp = logic_module(
-    "a41oi_lp",
+    "sky130_fd_sc_lp__a41oi_lp",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_m = logic_module(
-    "a41oi_m",
+    "sky130_fd_sc_lp__a41oi_m",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211o_0 = logic_module(
-    "a211o_0",
+    "sky130_fd_sc_lp__a211o_0",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_1 = logic_module(
-    "a211o_1",
+    "sky130_fd_sc_lp__a211o_1",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_2 = logic_module(
-    "a211o_2",
+    "sky130_fd_sc_lp__a211o_2",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_4 = logic_module(
-    "a211o_4",
+    "sky130_fd_sc_lp__a211o_4",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_lp = logic_module(
-    "a211o_lp",
+    "sky130_fd_sc_lp__a211o_lp",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_m = logic_module(
-    "a211o_m",
+    "sky130_fd_sc_lp__a211o_m",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211oi_0 = logic_module(
-    "a211oi_0",
+    "sky130_fd_sc_lp__a211oi_0",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_1 = logic_module(
-    "a211oi_1",
+    "sky130_fd_sc_lp__a211oi_1",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_2 = logic_module(
-    "a211oi_2",
+    "sky130_fd_sc_lp__a211oi_2",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_4 = logic_module(
-    "a211oi_4",
+    "sky130_fd_sc_lp__a211oi_4",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_lp = logic_module(
-    "a211oi_lp",
+    "sky130_fd_sc_lp__a211oi_lp",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_m = logic_module(
-    "a211oi_m",
+    "sky130_fd_sc_lp__a211oi_m",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221o_0 = logic_module(
-    "a221o_0",
+    "sky130_fd_sc_lp__a221o_0",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_1 = logic_module(
-    "a221o_1",
+    "sky130_fd_sc_lp__a221o_1",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_2 = logic_module(
-    "a221o_2",
+    "sky130_fd_sc_lp__a221o_2",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_4 = logic_module(
-    "a221o_4",
+    "sky130_fd_sc_lp__a221o_4",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_lp = logic_module(
-    "a221o_lp",
+    "sky130_fd_sc_lp__a221o_lp",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_m = logic_module(
-    "a221o_m",
+    "sky130_fd_sc_lp__a221o_m",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221oi_0 = logic_module(
-    "a221oi_0",
+    "sky130_fd_sc_lp__a221oi_0",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_1 = logic_module(
-    "a221oi_1",
+    "sky130_fd_sc_lp__a221oi_1",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_2 = logic_module(
-    "a221oi_2",
+    "sky130_fd_sc_lp__a221oi_2",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_4 = logic_module(
-    "a221oi_4",
+    "sky130_fd_sc_lp__a221oi_4",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_lp = logic_module(
-    "a221oi_lp",
+    "sky130_fd_sc_lp__a221oi_lp",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_m = logic_module(
-    "a221oi_m",
+    "sky130_fd_sc_lp__a221oi_m",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311o_0 = logic_module(
-    "a311o_0",
+    "sky130_fd_sc_lp__a311o_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_1 = logic_module(
-    "a311o_1",
+    "sky130_fd_sc_lp__a311o_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_2 = logic_module(
-    "a311o_2",
+    "sky130_fd_sc_lp__a311o_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_4 = logic_module(
-    "a311o_4",
+    "sky130_fd_sc_lp__a311o_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_lp = logic_module(
-    "a311o_lp",
+    "sky130_fd_sc_lp__a311o_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_m = logic_module(
-    "a311o_m",
+    "sky130_fd_sc_lp__a311o_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311oi_0 = logic_module(
-    "a311oi_0",
+    "sky130_fd_sc_lp__a311oi_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_1 = logic_module(
-    "a311oi_1",
+    "sky130_fd_sc_lp__a311oi_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_2 = logic_module(
-    "a311oi_2",
+    "sky130_fd_sc_lp__a311oi_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_4 = logic_module(
-    "a311oi_4",
+    "sky130_fd_sc_lp__a311oi_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_lp = logic_module(
-    "a311oi_lp",
+    "sky130_fd_sc_lp__a311oi_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_m = logic_module(
-    "a311oi_m",
+    "sky130_fd_sc_lp__a311oi_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111o_0 = logic_module(
-    "a2111o_0",
+    "sky130_fd_sc_lp__a2111o_0",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_1 = logic_module(
-    "a2111o_1",
+    "sky130_fd_sc_lp__a2111o_1",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_2 = logic_module(
-    "a2111o_2",
+    "sky130_fd_sc_lp__a2111o_2",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_4 = logic_module(
-    "a2111o_4",
+    "sky130_fd_sc_lp__a2111o_4",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_lp = logic_module(
-    "a2111o_lp",
+    "sky130_fd_sc_lp__a2111o_lp",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_m = logic_module(
-    "a2111o_m",
+    "sky130_fd_sc_lp__a2111o_m",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111oi_0 = logic_module(
-    "a2111oi_0",
+    "sky130_fd_sc_lp__a2111oi_0",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_1 = logic_module(
-    "a2111oi_1",
+    "sky130_fd_sc_lp__a2111oi_1",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_2 = logic_module(
-    "a2111oi_2",
+    "sky130_fd_sc_lp__a2111oi_2",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_4 = logic_module(
-    "a2111oi_4",
+    "sky130_fd_sc_lp__a2111oi_4",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_lp = logic_module(
-    "a2111oi_lp",
+    "sky130_fd_sc_lp__a2111oi_lp",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_m = logic_module(
-    "a2111oi_m",
+    "sky130_fd_sc_lp__a2111oi_m",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 and2_0 = logic_module(
-    "and2_0",
+    "sky130_fd_sc_lp__and2_0",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_1 = logic_module(
-    "and2_1",
+    "sky130_fd_sc_lp__and2_1",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_2 = logic_module(
-    "and2_2",
+    "sky130_fd_sc_lp__and2_2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_4 = logic_module(
-    "and2_4",
+    "sky130_fd_sc_lp__and2_4",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_lp2 = logic_module(
-    "and2_lp2",
+    "sky130_fd_sc_lp__and2_lp2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_lp = logic_module(
-    "and2_lp",
+    "sky130_fd_sc_lp__and2_lp",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_m = logic_module(
-    "and2_m",
+    "sky130_fd_sc_lp__and2_m",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_1 = logic_module(
-    "and2b_1",
+    "sky130_fd_sc_lp__and2b_1",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_2 = logic_module(
-    "and2b_2",
+    "sky130_fd_sc_lp__and2b_2",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_4 = logic_module(
-    "and2b_4",
+    "sky130_fd_sc_lp__and2b_4",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_lp = logic_module(
-    "and2b_lp",
+    "sky130_fd_sc_lp__and2b_lp",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_m = logic_module(
-    "and2b_m",
+    "sky130_fd_sc_lp__and2b_m",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_0 = logic_module(
-    "and3_0",
+    "sky130_fd_sc_lp__and3_0",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_1 = logic_module(
-    "and3_1",
+    "sky130_fd_sc_lp__and3_1",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_2 = logic_module(
-    "and3_2",
+    "sky130_fd_sc_lp__and3_2",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_4 = logic_module(
-    "and3_4",
+    "sky130_fd_sc_lp__and3_4",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_lp = logic_module(
-    "and3_lp",
+    "sky130_fd_sc_lp__and3_lp",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_m = logic_module(
-    "and3_m",
+    "sky130_fd_sc_lp__and3_m",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_1 = logic_module(
-    "and3b_1",
+    "sky130_fd_sc_lp__and3b_1",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_2 = logic_module(
-    "and3b_2",
+    "sky130_fd_sc_lp__and3b_2",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_4 = logic_module(
-    "and3b_4",
+    "sky130_fd_sc_lp__and3b_4",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_lp = logic_module(
-    "and3b_lp",
+    "sky130_fd_sc_lp__and3b_lp",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_m = logic_module(
-    "and3b_m",
+    "sky130_fd_sc_lp__and3b_m",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_0 = logic_module(
-    "and4_0",
+    "sky130_fd_sc_lp__and4_0",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_1 = logic_module(
-    "and4_1",
+    "sky130_fd_sc_lp__and4_1",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_2 = logic_module(
-    "and4_2",
+    "sky130_fd_sc_lp__and4_2",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_4 = logic_module(
-    "and4_4",
+    "sky130_fd_sc_lp__and4_4",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_lp2 = logic_module(
-    "and4_lp2",
+    "sky130_fd_sc_lp__and4_lp2",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_lp = logic_module(
-    "and4_lp",
+    "sky130_fd_sc_lp__and4_lp",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_m = logic_module(
-    "and4_m",
+    "sky130_fd_sc_lp__and4_m",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_1 = logic_module(
-    "and4b_1",
+    "sky130_fd_sc_lp__and4b_1",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_2 = logic_module(
-    "and4b_2",
+    "sky130_fd_sc_lp__and4b_2",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_4 = logic_module(
-    "and4b_4",
+    "sky130_fd_sc_lp__and4b_4",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_lp = logic_module(
-    "and4b_lp",
+    "sky130_fd_sc_lp__and4b_lp",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_m = logic_module(
-    "and4b_m",
+    "sky130_fd_sc_lp__and4b_m",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_1 = logic_module(
-    "and4bb_1",
+    "sky130_fd_sc_lp__and4bb_1",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_2 = logic_module(
-    "and4bb_2",
+    "sky130_fd_sc_lp__and4bb_2",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_4 = logic_module(
-    "and4bb_4",
+    "sky130_fd_sc_lp__and4bb_4",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_lp = logic_module(
-    "and4bb_lp",
+    "sky130_fd_sc_lp__and4bb_lp",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_m = logic_module(
-    "and4bb_m",
+    "sky130_fd_sc_lp__and4bb_m",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
-buf_0 = logic_module("buf_0", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_1 = logic_module("buf_1", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_2 = logic_module("buf_2", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_4 = logic_module("buf_4", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_8 = logic_module("buf_8", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_16 = logic_module("buf_16", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_lp = logic_module("buf_lp", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_m = logic_module("buf_m", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
+buf_0 = logic_module(
+    "sky130_fd_sc_lp__buf_0", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_1 = logic_module(
+    "sky130_fd_sc_lp__buf_1", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_2 = logic_module(
+    "sky130_fd_sc_lp__buf_2", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_4 = logic_module(
+    "sky130_fd_sc_lp__buf_4", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_8 = logic_module(
+    "sky130_fd_sc_lp__buf_8", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_16 = logic_module(
+    "sky130_fd_sc_lp__buf_16", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_lp = logic_module(
+    "sky130_fd_sc_lp__buf_lp", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_m = logic_module(
+    "sky130_fd_sc_lp__buf_m", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
 bufbuf_8 = logic_module(
-    "bufbuf_8",
+    "sky130_fd_sc_lp__bufbuf_8",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_16 = logic_module(
-    "bufbuf_16",
+    "sky130_fd_sc_lp__bufbuf_16",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufinv_8 = logic_module(
-    "bufinv_8",
+    "sky130_fd_sc_lp__bufinv_8",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 bufinv_16 = logic_module(
-    "bufinv_16",
+    "sky130_fd_sc_lp__bufinv_16",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 bufkapwr_1 = logic_module(
-    "bufkapwr_1",
+    "sky130_fd_sc_lp__bufkapwr_1",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufkapwr_2 = logic_module(
-    "bufkapwr_2",
+    "sky130_fd_sc_lp__bufkapwr_2",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufkapwr_4 = logic_module(
-    "bufkapwr_4",
+    "sky130_fd_sc_lp__bufkapwr_4",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufkapwr_8 = logic_module(
-    "bufkapwr_8",
+    "sky130_fd_sc_lp__bufkapwr_8",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buflp_0 = logic_module(
-    "buflp_0",
+    "sky130_fd_sc_lp__buflp_0",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buflp_1 = logic_module(
-    "buflp_1",
+    "sky130_fd_sc_lp__buflp_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buflp_2 = logic_module(
-    "buflp_2",
+    "sky130_fd_sc_lp__buflp_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buflp_4 = logic_module(
-    "buflp_4",
+    "sky130_fd_sc_lp__buflp_4",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buflp_8 = logic_module(
-    "buflp_8",
+    "sky130_fd_sc_lp__buflp_8",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buflp_m = logic_module(
-    "buflp_m",
+    "sky130_fd_sc_lp__buflp_m",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 busdriver2_20 = logic_module(
-    "busdriver2_20",
+    "sky130_fd_sc_lp__busdriver2_20",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 busdriver_20 = logic_module(
-    "busdriver_20",
+    "sky130_fd_sc_lp__busdriver_20",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 busdrivernovlp2_20 = logic_module(
-    "busdrivernovlp2_20",
+    "sky130_fd_sc_lp__busdrivernovlp2_20",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 busdrivernovlp_20 = logic_module(
-    "busdrivernovlp_20",
+    "sky130_fd_sc_lp__busdrivernovlp_20",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 busdrivernovlpsleep_20 = logic_module(
-    "busdrivernovlpsleep_20",
+    "sky130_fd_sc_lp__busdrivernovlpsleep_20",
     "Low Power",
     ["A", "SLEEP", "TE_B", "KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 bushold0_1 = logic_module(
-    "bushold0_1",
+    "sky130_fd_sc_lp__bushold0_1",
     "Low Power",
     ["RESET", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bushold_1 = logic_module(
-    "bushold_1",
+    "sky130_fd_sc_lp__bushold_1",
     "Low Power",
     ["RESET", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 busreceiver_0 = logic_module(
-    "busreceiver_0",
+    "sky130_fd_sc_lp__busreceiver_0",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 busreceiver_1 = logic_module(
-    "busreceiver_1",
+    "sky130_fd_sc_lp__busreceiver_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 busreceiver_m = logic_module(
-    "busreceiver_m",
+    "sky130_fd_sc_lp__busreceiver_m",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_0 = logic_module(
-    "clkbuf_0",
+    "sky130_fd_sc_lp__clkbuf_0",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_1 = logic_module(
-    "clkbuf_1",
+    "sky130_fd_sc_lp__clkbuf_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_2 = logic_module(
-    "clkbuf_2",
+    "sky130_fd_sc_lp__clkbuf_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_4 = logic_module(
-    "clkbuf_4",
+    "sky130_fd_sc_lp__clkbuf_4",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_8 = logic_module(
-    "clkbuf_8",
+    "sky130_fd_sc_lp__clkbuf_8",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_16 = logic_module(
-    "clkbuf_16",
+    "sky130_fd_sc_lp__clkbuf_16",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_lp = logic_module(
-    "clkbuf_lp",
+    "sky130_fd_sc_lp__clkbuf_lp",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuflp_2 = logic_module(
-    "clkbuflp_2",
+    "sky130_fd_sc_lp__clkbuflp_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuflp_4 = logic_module(
-    "clkbuflp_4",
+    "sky130_fd_sc_lp__clkbuflp_4",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuflp_8 = logic_module(
-    "clkbuflp_8",
+    "sky130_fd_sc_lp__clkbuflp_8",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuflp_16 = logic_module(
-    "clkbuflp_16",
+    "sky130_fd_sc_lp__clkbuflp_16",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s15_1 = logic_module(
-    "clkdlybuf4s15_1",
+    "sky130_fd_sc_lp__clkdlybuf4s15_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s15_2 = logic_module(
-    "clkdlybuf4s15_2",
+    "sky130_fd_sc_lp__clkdlybuf4s15_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s18_1 = logic_module(
-    "clkdlybuf4s18_1",
+    "sky130_fd_sc_lp__clkdlybuf4s18_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s18_2 = logic_module(
-    "clkdlybuf4s18_2",
+    "sky130_fd_sc_lp__clkdlybuf4s18_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s25_1 = logic_module(
-    "clkdlybuf4s25_1",
+    "sky130_fd_sc_lp__clkdlybuf4s25_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s25_2 = logic_module(
-    "clkdlybuf4s25_2",
+    "sky130_fd_sc_lp__clkdlybuf4s25_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s50_1 = logic_module(
-    "clkdlybuf4s50_1",
+    "sky130_fd_sc_lp__clkdlybuf4s50_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlybuf4s50_2 = logic_module(
-    "clkdlybuf4s50_2",
+    "sky130_fd_sc_lp__clkdlybuf4s50_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkinv_0 = logic_module(
-    "clkinv_0",
+    "sky130_fd_sc_lp__clkinv_0",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_1 = logic_module(
-    "clkinv_1",
+    "sky130_fd_sc_lp__clkinv_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_2 = logic_module(
-    "clkinv_2",
+    "sky130_fd_sc_lp__clkinv_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_4 = logic_module(
-    "clkinv_4",
+    "sky130_fd_sc_lp__clkinv_4",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_8 = logic_module(
-    "clkinv_8",
+    "sky130_fd_sc_lp__clkinv_8",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_16 = logic_module(
-    "clkinv_16",
+    "sky130_fd_sc_lp__clkinv_16",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_lp2 = logic_module(
-    "clkinv_lp2",
+    "sky130_fd_sc_lp__clkinv_lp2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_lp = logic_module(
-    "clkinv_lp",
+    "sky130_fd_sc_lp__clkinv_lp",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinvlp_2 = logic_module(
-    "clkinvlp_2",
+    "sky130_fd_sc_lp__clkinvlp_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinvlp_4 = logic_module(
-    "clkinvlp_4",
+    "sky130_fd_sc_lp__clkinvlp_4",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinvlp_8 = logic_module(
-    "clkinvlp_8",
+    "sky130_fd_sc_lp__clkinvlp_8",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinvlp_16 = logic_module(
-    "clkinvlp_16",
+    "sky130_fd_sc_lp__clkinvlp_16",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 conb_0 = logic_module(
-    "conb_0",
+    "sky130_fd_sc_lp__conb_0",
     "Low Power",
     ["VGND", "VNB", "VPB", "VPWR", "HI", "LO"],
 )
 conb_1 = logic_module(
-    "conb_1",
+    "sky130_fd_sc_lp__conb_1",
     "Low Power",
     ["VGND", "VNB", "VPB", "VPWR", "HI", "LO"],
 )
-decap_3 = logic_module("decap_3", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-decap_4 = logic_module("decap_4", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-decap_6 = logic_module("decap_6", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-decap_8 = logic_module("decap_8", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-decap_12 = logic_module("decap_12", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
+decap_3 = logic_module(
+    "sky130_fd_sc_lp__decap_3", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_4 = logic_module(
+    "sky130_fd_sc_lp__decap_4", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_6 = logic_module(
+    "sky130_fd_sc_lp__decap_6", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_8 = logic_module(
+    "sky130_fd_sc_lp__decap_8", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_12 = logic_module(
+    "sky130_fd_sc_lp__decap_12", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
 decapkapwr_3 = logic_module(
-    "decapkapwr_3",
+    "sky130_fd_sc_lp__decapkapwr_3",
     "Low Power",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 decapkapwr_4 = logic_module(
-    "decapkapwr_4",
+    "sky130_fd_sc_lp__decapkapwr_4",
     "Low Power",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 decapkapwr_6 = logic_module(
-    "decapkapwr_6",
+    "sky130_fd_sc_lp__decapkapwr_6",
     "Low Power",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 decapkapwr_8 = logic_module(
-    "decapkapwr_8",
+    "sky130_fd_sc_lp__decapkapwr_8",
     "Low Power",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 decapkapwr_12 = logic_module(
-    "decapkapwr_12",
+    "sky130_fd_sc_lp__decapkapwr_12",
     "Low Power",
     ["KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 dfbbn_1 = logic_module(
-    "dfbbn_1",
+    "sky130_fd_sc_lp__dfbbn_1",
     "Low Power",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbn_2 = logic_module(
-    "dfbbn_2",
+    "sky130_fd_sc_lp__dfbbn_2",
     "Low Power",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbp_1 = logic_module(
-    "dfbbp_1",
+    "sky130_fd_sc_lp__dfbbp_1",
     "Low Power",
     ["CLK", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_1 = logic_module(
-    "dfrbp_1",
+    "sky130_fd_sc_lp__dfrbp_1",
     "Low Power",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_2 = logic_module(
-    "dfrbp_2",
+    "sky130_fd_sc_lp__dfrbp_2",
     "Low Power",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_lp = logic_module(
-    "dfrbp_lp",
+    "sky130_fd_sc_lp__dfrbp_lp",
     "Low Power",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrtn_1 = logic_module(
-    "dfrtn_1",
+    "sky130_fd_sc_lp__dfrtn_1",
     "Low Power",
     ["CLK_N", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_1 = logic_module(
-    "dfrtp_1",
+    "sky130_fd_sc_lp__dfrtp_1",
     "Low Power",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_2 = logic_module(
-    "dfrtp_2",
+    "sky130_fd_sc_lp__dfrtp_2",
     "Low Power",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_4 = logic_module(
-    "dfrtp_4",
+    "sky130_fd_sc_lp__dfrtp_4",
     "Low Power",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfsbp_1 = logic_module(
-    "dfsbp_1",
+    "sky130_fd_sc_lp__dfsbp_1",
     "Low Power",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfsbp_2 = logic_module(
-    "dfsbp_2",
+    "sky130_fd_sc_lp__dfsbp_2",
     "Low Power",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfsbp_lp = logic_module(
-    "dfsbp_lp",
+    "sky130_fd_sc_lp__dfsbp_lp",
     "Low Power",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfstp_1 = logic_module(
-    "dfstp_1",
+    "sky130_fd_sc_lp__dfstp_1",
     "Low Power",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_2 = logic_module(
-    "dfstp_2",
+    "sky130_fd_sc_lp__dfstp_2",
     "Low Power",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_4 = logic_module(
-    "dfstp_4",
+    "sky130_fd_sc_lp__dfstp_4",
     "Low Power",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_lp = logic_module(
-    "dfstp_lp",
+    "sky130_fd_sc_lp__dfstp_lp",
     "Low Power",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxbp_1 = logic_module(
-    "dfxbp_1",
+    "sky130_fd_sc_lp__dfxbp_1",
     "Low Power",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxbp_2 = logic_module(
-    "dfxbp_2",
+    "sky130_fd_sc_lp__dfxbp_2",
     "Low Power",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxbp_lp = logic_module(
-    "dfxbp_lp",
+    "sky130_fd_sc_lp__dfxbp_lp",
     "Low Power",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxtp_1 = logic_module(
-    "dfxtp_1",
+    "sky130_fd_sc_lp__dfxtp_1",
     "Low Power",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_2 = logic_module(
-    "dfxtp_2",
+    "sky130_fd_sc_lp__dfxtp_2",
     "Low Power",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_4 = logic_module(
-    "dfxtp_4",
+    "sky130_fd_sc_lp__dfxtp_4",
     "Low Power",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_lp = logic_module(
-    "dfxtp_lp",
+    "sky130_fd_sc_lp__dfxtp_lp",
     "Low Power",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
-diode_0 = logic_module("diode_0", "Low Power", ["DIODE", "VGND", "VNB", "VPB", "VPWR"])
-diode_1 = logic_module("diode_1", "Low Power", ["DIODE", "VGND", "VNB", "VPB", "VPWR"])
+diode_0 = logic_module(
+    "sky130_fd_sc_lp__diode_0", "Low Power", ["DIODE", "VGND", "VNB", "VPB", "VPWR"]
+)
+diode_1 = logic_module(
+    "sky130_fd_sc_lp__diode_1", "Low Power", ["DIODE", "VGND", "VNB", "VPB", "VPWR"]
+)
 dlclkp_1 = logic_module(
-    "dlclkp_1",
+    "sky130_fd_sc_lp__dlclkp_1",
     "Low Power",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_2 = logic_module(
-    "dlclkp_2",
+    "sky130_fd_sc_lp__dlclkp_2",
     "Low Power",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_4 = logic_module(
-    "dlclkp_4",
+    "sky130_fd_sc_lp__dlclkp_4",
     "Low Power",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_lp = logic_module(
-    "dlclkp_lp",
+    "sky130_fd_sc_lp__dlclkp_lp",
     "Low Power",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlrbn_1 = logic_module(
-    "dlrbn_1",
+    "sky130_fd_sc_lp__dlrbn_1",
     "Low Power",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbn_2 = logic_module(
-    "dlrbn_2",
+    "sky130_fd_sc_lp__dlrbn_2",
     "Low Power",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbn_lp = logic_module(
-    "dlrbn_lp",
+    "sky130_fd_sc_lp__dlrbn_lp",
     "Low Power",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_1 = logic_module(
-    "dlrbp_1",
+    "sky130_fd_sc_lp__dlrbp_1",
     "Low Power",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_2 = logic_module(
-    "dlrbp_2",
+    "sky130_fd_sc_lp__dlrbp_2",
     "Low Power",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_lp = logic_module(
-    "dlrbp_lp",
+    "sky130_fd_sc_lp__dlrbp_lp",
     "Low Power",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrtn_1 = logic_module(
-    "dlrtn_1",
+    "sky130_fd_sc_lp__dlrtn_1",
     "Low Power",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_2 = logic_module(
-    "dlrtn_2",
+    "sky130_fd_sc_lp__dlrtn_2",
     "Low Power",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_4 = logic_module(
-    "dlrtn_4",
+    "sky130_fd_sc_lp__dlrtn_4",
     "Low Power",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_lp = logic_module(
-    "dlrtn_lp",
+    "sky130_fd_sc_lp__dlrtn_lp",
     "Low Power",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_1 = logic_module(
-    "dlrtp_1",
+    "sky130_fd_sc_lp__dlrtp_1",
     "Low Power",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_2 = logic_module(
-    "dlrtp_2",
+    "sky130_fd_sc_lp__dlrtp_2",
     "Low Power",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_4 = logic_module(
-    "dlrtp_4",
+    "sky130_fd_sc_lp__dlrtp_4",
     "Low Power",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_lp2 = logic_module(
-    "dlrtp_lp2",
+    "sky130_fd_sc_lp__dlrtp_lp2",
     "Low Power",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_lp = logic_module(
-    "dlrtp_lp",
+    "sky130_fd_sc_lp__dlrtp_lp",
     "Low Power",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxbn_1 = logic_module(
-    "dlxbn_1",
+    "sky130_fd_sc_lp__dlxbn_1",
     "Low Power",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbn_2 = logic_module(
-    "dlxbn_2",
+    "sky130_fd_sc_lp__dlxbn_2",
     "Low Power",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbp_1 = logic_module(
-    "dlxbp_1",
+    "sky130_fd_sc_lp__dlxbp_1",
     "Low Power",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbp_lp2 = logic_module(
-    "dlxbp_lp2",
+    "sky130_fd_sc_lp__dlxbp_lp2",
     "Low Power",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbp_lp = logic_module(
-    "dlxbp_lp",
+    "sky130_fd_sc_lp__dlxbp_lp",
     "Low Power",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxtn_1 = logic_module(
-    "dlxtn_1",
+    "sky130_fd_sc_lp__dlxtn_1",
     "Low Power",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_2 = logic_module(
-    "dlxtn_2",
+    "sky130_fd_sc_lp__dlxtn_2",
     "Low Power",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_4 = logic_module(
-    "dlxtn_4",
+    "sky130_fd_sc_lp__dlxtn_4",
     "Low Power",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtp_1 = logic_module(
-    "dlxtp_1",
+    "sky130_fd_sc_lp__dlxtp_1",
     "Low Power",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtp_lp2 = logic_module(
-    "dlxtp_lp2",
+    "sky130_fd_sc_lp__dlxtp_lp2",
     "Low Power",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtp_lp = logic_module(
-    "dlxtp_lp",
+    "sky130_fd_sc_lp__dlxtp_lp",
     "Low Power",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlybuf4s15kapwr_1 = logic_module(
-    "dlybuf4s15kapwr_1",
+    "sky130_fd_sc_lp__dlybuf4s15kapwr_1",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlybuf4s15kapwr_2 = logic_module(
-    "dlybuf4s15kapwr_2",
+    "sky130_fd_sc_lp__dlybuf4s15kapwr_2",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlybuf4s18kapwr_1 = logic_module(
-    "dlybuf4s18kapwr_1",
+    "sky130_fd_sc_lp__dlybuf4s18kapwr_1",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlybuf4s18kapwr_2 = logic_module(
-    "dlybuf4s18kapwr_2",
+    "sky130_fd_sc_lp__dlybuf4s18kapwr_2",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlybuf4s25kapwr_1 = logic_module(
-    "dlybuf4s25kapwr_1",
+    "sky130_fd_sc_lp__dlybuf4s25kapwr_1",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlybuf4s25kapwr_2 = logic_module(
-    "dlybuf4s25kapwr_2",
+    "sky130_fd_sc_lp__dlybuf4s25kapwr_2",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlybuf4s50kapwr_1 = logic_module(
-    "dlybuf4s50kapwr_1",
+    "sky130_fd_sc_lp__dlybuf4s50kapwr_1",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlybuf4s50kapwr_2 = logic_module(
-    "dlybuf4s50kapwr_2",
+    "sky130_fd_sc_lp__dlybuf4s50kapwr_2",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4s15_1 = logic_module(
-    "dlygate4s15_1",
+    "sky130_fd_sc_lp__dlygate4s15_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4s18_1 = logic_module(
-    "dlygate4s18_1",
+    "sky130_fd_sc_lp__dlygate4s18_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4s50_1 = logic_module(
-    "dlygate4s50_1",
+    "sky130_fd_sc_lp__dlygate4s50_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s2s_1 = logic_module(
-    "dlymetal6s2s_1",
+    "sky130_fd_sc_lp__dlymetal6s2s_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s4s_1 = logic_module(
-    "dlymetal6s4s_1",
+    "sky130_fd_sc_lp__dlymetal6s4s_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s6s_1 = logic_module(
-    "dlymetal6s6s_1",
+    "sky130_fd_sc_lp__dlymetal6s6s_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 ebufn_1 = logic_module(
-    "ebufn_1",
+    "sky130_fd_sc_lp__ebufn_1",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_2 = logic_module(
-    "ebufn_2",
+    "sky130_fd_sc_lp__ebufn_2",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_4 = logic_module(
-    "ebufn_4",
+    "sky130_fd_sc_lp__ebufn_4",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_8 = logic_module(
-    "ebufn_8",
+    "sky130_fd_sc_lp__ebufn_8",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_lp2 = logic_module(
-    "ebufn_lp2",
+    "sky130_fd_sc_lp__ebufn_lp2",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_lp = logic_module(
-    "ebufn_lp",
+    "sky130_fd_sc_lp__ebufn_lp",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 edfxbp_1 = logic_module(
-    "edfxbp_1",
+    "sky130_fd_sc_lp__edfxbp_1",
     "Low Power",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 einvn_0 = logic_module(
-    "einvn_0",
+    "sky130_fd_sc_lp__einvn_0",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_1 = logic_module(
-    "einvn_1",
+    "sky130_fd_sc_lp__einvn_1",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_2 = logic_module(
-    "einvn_2",
+    "sky130_fd_sc_lp__einvn_2",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_4 = logic_module(
-    "einvn_4",
+    "sky130_fd_sc_lp__einvn_4",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_8 = logic_module(
-    "einvn_8",
+    "sky130_fd_sc_lp__einvn_8",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_lp = logic_module(
-    "einvn_lp",
+    "sky130_fd_sc_lp__einvn_lp",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_m = logic_module(
-    "einvn_m",
+    "sky130_fd_sc_lp__einvn_m",
     "Low Power",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_0 = logic_module(
-    "einvp_0",
+    "sky130_fd_sc_lp__einvp_0",
     "Low Power",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_1 = logic_module(
-    "einvp_1",
+    "sky130_fd_sc_lp__einvp_1",
     "Low Power",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_2 = logic_module(
-    "einvp_2",
+    "sky130_fd_sc_lp__einvp_2",
     "Low Power",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_4 = logic_module(
-    "einvp_4",
+    "sky130_fd_sc_lp__einvp_4",
     "Low Power",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_8 = logic_module(
-    "einvp_8",
+    "sky130_fd_sc_lp__einvp_8",
     "Low Power",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_lp = logic_module(
-    "einvp_lp",
+    "sky130_fd_sc_lp__einvp_lp",
     "Low Power",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_m = logic_module(
-    "einvp_m",
+    "sky130_fd_sc_lp__einvp_m",
     "Low Power",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 fa_0 = logic_module(
-    "fa_0",
+    "sky130_fd_sc_lp__fa_0",
     "Low Power",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_1 = logic_module(
-    "fa_1",
+    "sky130_fd_sc_lp__fa_1",
     "Low Power",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_2 = logic_module(
-    "fa_2",
+    "sky130_fd_sc_lp__fa_2",
     "Low Power",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_4 = logic_module(
-    "fa_4",
+    "sky130_fd_sc_lp__fa_4",
     "Low Power",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_lp = logic_module(
-    "fa_lp",
+    "sky130_fd_sc_lp__fa_lp",
     "Low Power",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_m = logic_module(
-    "fa_m",
+    "sky130_fd_sc_lp__fa_m",
     "Low Power",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_1 = logic_module(
-    "fah_1",
+    "sky130_fd_sc_lp__fah_1",
     "Low Power",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcin_1 = logic_module(
-    "fahcin_1",
+    "sky130_fd_sc_lp__fahcin_1",
     "Low Power",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcon_1 = logic_module(
-    "fahcon_1",
+    "sky130_fd_sc_lp__fahcon_1",
     "Low Power",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT_N", "SUM"],
 )
-fill_1 = logic_module("fill_1", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-fill_2 = logic_module("fill_2", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-fill_4 = logic_module("fill_4", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-fill_8 = logic_module("fill_8", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
+fill_1 = logic_module(
+    "sky130_fd_sc_lp__fill_1", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_2 = logic_module(
+    "sky130_fd_sc_lp__fill_2", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_4 = logic_module(
+    "sky130_fd_sc_lp__fill_4", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_8 = logic_module(
+    "sky130_fd_sc_lp__fill_8", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
 ha_0 = logic_module(
-    "ha_0",
+    "sky130_fd_sc_lp__ha_0",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_1 = logic_module(
-    "ha_1",
+    "sky130_fd_sc_lp__ha_1",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_2 = logic_module(
-    "ha_2",
+    "sky130_fd_sc_lp__ha_2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_4 = logic_module(
-    "ha_4",
+    "sky130_fd_sc_lp__ha_4",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_lp = logic_module(
-    "ha_lp",
+    "sky130_fd_sc_lp__ha_lp",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_m = logic_module(
-    "ha_m",
+    "sky130_fd_sc_lp__ha_m",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 inputiso0n_lp = logic_module(
-    "inputiso0n_lp",
+    "sky130_fd_sc_lp__inputiso0n_lp",
     "Low Power",
     ["A", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 inputiso0p_lp = logic_module(
-    "inputiso0p_lp",
+    "sky130_fd_sc_lp__inputiso0p_lp",
     "Low Power",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 inputiso1n_lp = logic_module(
-    "inputiso1n_lp",
+    "sky130_fd_sc_lp__inputiso1n_lp",
     "Low Power",
     ["A", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 inputiso1p_lp = logic_module(
-    "inputiso1p_lp",
+    "sky130_fd_sc_lp__inputiso1p_lp",
     "Low Power",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 inputisolatch_lp = logic_module(
-    "inputisolatch_lp",
+    "sky130_fd_sc_lp__inputisolatch_lp",
     "Low Power",
     ["D", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
-inv_0 = logic_module("inv_0", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_1 = logic_module("inv_1", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_2 = logic_module("inv_2", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_4 = logic_module("inv_4", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_8 = logic_module("inv_8", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_16 = logic_module("inv_16", "Low Power", ["A", "VGND", "VNB", "VPB", "Y"])
-inv_lp = logic_module("inv_lp", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_m = logic_module("inv_m", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
+inv_0 = logic_module(
+    "sky130_fd_sc_lp__inv_0", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_1 = logic_module(
+    "sky130_fd_sc_lp__inv_1", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_2 = logic_module(
+    "sky130_fd_sc_lp__inv_2", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_4 = logic_module(
+    "sky130_fd_sc_lp__inv_4", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_8 = logic_module(
+    "sky130_fd_sc_lp__inv_8", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_16 = logic_module(
+    "sky130_fd_sc_lp__inv_16", "Low Power", ["A", "VGND", "VNB", "VPB", "Y"]
+)
+inv_lp = logic_module(
+    "sky130_fd_sc_lp__inv_lp", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_m = logic_module(
+    "sky130_fd_sc_lp__inv_m", "Low Power", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
 invkapwr_1 = logic_module(
-    "invkapwr_1",
+    "sky130_fd_sc_lp__invkapwr_1",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invkapwr_2 = logic_module(
-    "invkapwr_2",
+    "sky130_fd_sc_lp__invkapwr_2",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invkapwr_4 = logic_module(
-    "invkapwr_4",
+    "sky130_fd_sc_lp__invkapwr_4",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invkapwr_8 = logic_module(
-    "invkapwr_8",
+    "sky130_fd_sc_lp__invkapwr_8",
     "Low Power",
     ["A", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invlp_0 = logic_module(
-    "invlp_0",
+    "sky130_fd_sc_lp__invlp_0",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invlp_1 = logic_module(
-    "invlp_1",
+    "sky130_fd_sc_lp__invlp_1",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invlp_2 = logic_module(
-    "invlp_2",
+    "sky130_fd_sc_lp__invlp_2",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invlp_4 = logic_module(
-    "invlp_4",
+    "sky130_fd_sc_lp__invlp_4",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invlp_8 = logic_module(
-    "invlp_8",
+    "sky130_fd_sc_lp__invlp_8",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 invlp_m = logic_module(
-    "invlp_m",
+    "sky130_fd_sc_lp__invlp_m",
     "Low Power",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 iso0n_lp2 = logic_module(
-    "iso0n_lp2",
+    "sky130_fd_sc_lp__iso0n_lp2",
     "Low Power",
     ["A", "SLEEP_B", "KAGND", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 iso0n_lp = logic_module(
-    "iso0n_lp",
+    "sky130_fd_sc_lp__iso0n_lp",
     "Low Power",
     ["A", "KAGND", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 iso0p_lp2 = logic_module(
-    "iso0p_lp2",
+    "sky130_fd_sc_lp__iso0p_lp2",
     "Low Power",
     ["A", "SLEEP", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 iso0p_lp = logic_module(
-    "iso0p_lp",
+    "sky130_fd_sc_lp__iso0p_lp",
     "Low Power",
     ["A", "KAPWR", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 iso1n_lp2 = logic_module(
-    "iso1n_lp2",
+    "sky130_fd_sc_lp__iso1n_lp2",
     "Low Power",
     ["A", "SLEEP_B", "KAGND", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 iso1n_lp = logic_module(
-    "iso1n_lp",
+    "sky130_fd_sc_lp__iso1n_lp",
     "Low Power",
     ["A", "KAGND", "SLEEP_B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 iso1p_lp2 = logic_module(
-    "iso1p_lp2",
+    "sky130_fd_sc_lp__iso1p_lp2",
     "Low Power",
     ["A", "SLEEP", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 iso1p_lp = logic_module(
-    "iso1p_lp",
+    "sky130_fd_sc_lp__iso1p_lp",
     "Low Power",
     ["A", "KAPWR", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 isobufsrc_1 = logic_module(
-    "isobufsrc_1",
+    "sky130_fd_sc_lp__isobufsrc_1",
     "Low Power",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 isobufsrc_2 = logic_module(
-    "isobufsrc_2",
+    "sky130_fd_sc_lp__isobufsrc_2",
     "Low Power",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 isobufsrc_4 = logic_module(
-    "isobufsrc_4",
+    "sky130_fd_sc_lp__isobufsrc_4",
     "Low Power",
     ["A", "SLEEP", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 isolatch_lp = logic_module(
-    "isolatch_lp",
+    "sky130_fd_sc_lp__isolatch_lp",
     "Low Power",
     ["D", "SLEEP_B", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 lsbuf_lp = logic_module(
-    "lsbuf_lp",
+    "sky130_fd_sc_lp__lsbuf_lp",
     "Low Power",
     ["A", "DESTPWR", "DESTVPB", "VGND", "VPB", "VPWR", "X"],
 )
 lsbufiso0p_lp = logic_module(
-    "lsbufiso0p_lp",
+    "sky130_fd_sc_lp__lsbufiso0p_lp",
     "Low Power",
     ["A", "DESTPWR", "DESTVPB", "SLEEP", "VGND", "VPB", "VPWR", "X"],
 )
 lsbufiso1p_lp = logic_module(
-    "lsbufiso1p_lp",
+    "sky130_fd_sc_lp__lsbufiso1p_lp",
     "Low Power",
     ["A", "DESTPWR", "DESTVPB", "SLEEP", "VGND", "VPB", "VPWR", "X"],
 )
 maj3_0 = logic_module(
-    "maj3_0",
+    "sky130_fd_sc_lp__maj3_0",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_1 = logic_module(
-    "maj3_1",
+    "sky130_fd_sc_lp__maj3_1",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_2 = logic_module(
-    "maj3_2",
+    "sky130_fd_sc_lp__maj3_2",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_4 = logic_module(
-    "maj3_4",
+    "sky130_fd_sc_lp__maj3_4",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_lp = logic_module(
-    "maj3_lp",
+    "sky130_fd_sc_lp__maj3_lp",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_m = logic_module(
-    "maj3_m",
+    "sky130_fd_sc_lp__maj3_m",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_0 = logic_module(
-    "mux2_0",
+    "sky130_fd_sc_lp__mux2_0",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_1 = logic_module(
-    "mux2_1",
+    "sky130_fd_sc_lp__mux2_1",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_2 = logic_module(
-    "mux2_2",
+    "sky130_fd_sc_lp__mux2_2",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_4 = logic_module(
-    "mux2_4",
+    "sky130_fd_sc_lp__mux2_4",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_8 = logic_module(
-    "mux2_8",
+    "sky130_fd_sc_lp__mux2_8",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_lp2 = logic_module(
-    "mux2_lp2",
+    "sky130_fd_sc_lp__mux2_lp2",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_lp = logic_module(
-    "mux2_lp",
+    "sky130_fd_sc_lp__mux2_lp",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_m = logic_module(
-    "mux2_m",
+    "sky130_fd_sc_lp__mux2_m",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2i_0 = logic_module(
-    "mux2i_0",
+    "sky130_fd_sc_lp__mux2i_0",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_1 = logic_module(
-    "mux2i_1",
+    "sky130_fd_sc_lp__mux2i_1",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_2 = logic_module(
-    "mux2i_2",
+    "sky130_fd_sc_lp__mux2i_2",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_4 = logic_module(
-    "mux2i_4",
+    "sky130_fd_sc_lp__mux2i_4",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_lp2 = logic_module(
-    "mux2i_lp2",
+    "sky130_fd_sc_lp__mux2i_lp2",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_lp = logic_module(
-    "mux2i_lp",
+    "sky130_fd_sc_lp__mux2i_lp",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_m = logic_module(
-    "mux2i_m",
+    "sky130_fd_sc_lp__mux2i_m",
     "Low Power",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux4_0 = logic_module(
-    "mux4_0",
+    "sky130_fd_sc_lp__mux4_0",
     "Low Power",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_1 = logic_module(
-    "mux4_1",
+    "sky130_fd_sc_lp__mux4_1",
     "Low Power",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_2 = logic_module(
-    "mux4_2",
+    "sky130_fd_sc_lp__mux4_2",
     "Low Power",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_4 = logic_module(
-    "mux4_4",
+    "sky130_fd_sc_lp__mux4_4",
     "Low Power",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_lp = logic_module(
-    "mux4_lp",
+    "sky130_fd_sc_lp__mux4_lp",
     "Low Power",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_m = logic_module(
-    "mux4_m",
+    "sky130_fd_sc_lp__mux4_m",
     "Low Power",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 nand2_0 = logic_module(
-    "nand2_0",
+    "sky130_fd_sc_lp__nand2_0",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_1 = logic_module(
-    "nand2_1",
+    "sky130_fd_sc_lp__nand2_1",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_2 = logic_module(
-    "nand2_2",
+    "sky130_fd_sc_lp__nand2_2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_4 = logic_module(
-    "nand2_4",
+    "sky130_fd_sc_lp__nand2_4",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_8 = logic_module(
-    "nand2_8",
+    "sky130_fd_sc_lp__nand2_8",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_lp2 = logic_module(
-    "nand2_lp2",
+    "sky130_fd_sc_lp__nand2_lp2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_lp = logic_module(
-    "nand2_lp",
+    "sky130_fd_sc_lp__nand2_lp",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_m = logic_module(
-    "nand2_m",
+    "sky130_fd_sc_lp__nand2_m",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_1 = logic_module(
-    "nand2b_1",
+    "sky130_fd_sc_lp__nand2b_1",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_2 = logic_module(
-    "nand2b_2",
+    "sky130_fd_sc_lp__nand2b_2",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_4 = logic_module(
-    "nand2b_4",
+    "sky130_fd_sc_lp__nand2b_4",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_lp = logic_module(
-    "nand2b_lp",
+    "sky130_fd_sc_lp__nand2b_lp",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_m = logic_module(
-    "nand2b_m",
+    "sky130_fd_sc_lp__nand2b_m",
     "Low Power",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_0 = logic_module(
-    "nand3_0",
+    "sky130_fd_sc_lp__nand3_0",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_1 = logic_module(
-    "nand3_1",
+    "sky130_fd_sc_lp__nand3_1",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_2 = logic_module(
-    "nand3_2",
+    "sky130_fd_sc_lp__nand3_2",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_4 = logic_module(
-    "nand3_4",
+    "sky130_fd_sc_lp__nand3_4",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_lp = logic_module(
-    "nand3_lp",
+    "sky130_fd_sc_lp__nand3_lp",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_m = logic_module(
-    "nand3_m",
+    "sky130_fd_sc_lp__nand3_m",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_1 = logic_module(
-    "nand3b_1",
+    "sky130_fd_sc_lp__nand3b_1",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_2 = logic_module(
-    "nand3b_2",
+    "sky130_fd_sc_lp__nand3b_2",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_4 = logic_module(
-    "nand3b_4",
+    "sky130_fd_sc_lp__nand3b_4",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_lp = logic_module(
-    "nand3b_lp",
+    "sky130_fd_sc_lp__nand3b_lp",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_m = logic_module(
-    "nand3b_m",
+    "sky130_fd_sc_lp__nand3b_m",
     "Low Power",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_0 = logic_module(
-    "nand4_0",
+    "sky130_fd_sc_lp__nand4_0",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_1 = logic_module(
-    "nand4_1",
+    "sky130_fd_sc_lp__nand4_1",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_2 = logic_module(
-    "nand4_2",
+    "sky130_fd_sc_lp__nand4_2",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_4 = logic_module(
-    "nand4_4",
+    "sky130_fd_sc_lp__nand4_4",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_lp = logic_module(
-    "nand4_lp",
+    "sky130_fd_sc_lp__nand4_lp",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_m = logic_module(
-    "nand4_m",
+    "sky130_fd_sc_lp__nand4_m",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_1 = logic_module(
-    "nand4b_1",
+    "sky130_fd_sc_lp__nand4b_1",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_2 = logic_module(
-    "nand4b_2",
+    "sky130_fd_sc_lp__nand4b_2",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_4 = logic_module(
-    "nand4b_4",
+    "sky130_fd_sc_lp__nand4b_4",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_lp = logic_module(
-    "nand4b_lp",
+    "sky130_fd_sc_lp__nand4b_lp",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_m = logic_module(
-    "nand4b_m",
+    "sky130_fd_sc_lp__nand4b_m",
     "Low Power",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_1 = logic_module(
-    "nand4bb_1",
+    "sky130_fd_sc_lp__nand4bb_1",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_2 = logic_module(
-    "nand4bb_2",
+    "sky130_fd_sc_lp__nand4bb_2",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_4 = logic_module(
-    "nand4bb_4",
+    "sky130_fd_sc_lp__nand4bb_4",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_lp = logic_module(
-    "nand4bb_lp",
+    "sky130_fd_sc_lp__nand4bb_lp",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_m = logic_module(
-    "nand4bb_m",
+    "sky130_fd_sc_lp__nand4bb_m",
     "Low Power",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_0 = logic_module(
-    "nor2_0",
+    "sky130_fd_sc_lp__nor2_0",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_1 = logic_module(
-    "nor2_1",
+    "sky130_fd_sc_lp__nor2_1",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_2 = logic_module(
-    "nor2_2",
+    "sky130_fd_sc_lp__nor2_2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_4 = logic_module(
-    "nor2_4",
+    "sky130_fd_sc_lp__nor2_4",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_8 = logic_module(
-    "nor2_8",
+    "sky130_fd_sc_lp__nor2_8",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_lp2 = logic_module(
-    "nor2_lp2",
+    "sky130_fd_sc_lp__nor2_lp2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
-nor2_lp = logic_module("nor2_lp", "Low Power", ["A", "B", "VNB", "VPB", "Y"])
+nor2_lp = logic_module(
+    "sky130_fd_sc_lp__nor2_lp", "Low Power", ["A", "B", "VNB", "VPB", "Y"]
+)
 nor2_m = logic_module(
-    "nor2_m",
+    "sky130_fd_sc_lp__nor2_m",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_1 = logic_module(
-    "nor2b_1",
+    "sky130_fd_sc_lp__nor2b_1",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_2 = logic_module(
-    "nor2b_2",
+    "sky130_fd_sc_lp__nor2b_2",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_4 = logic_module(
-    "nor2b_4",
+    "sky130_fd_sc_lp__nor2b_4",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_lp = logic_module(
-    "nor2b_lp",
+    "sky130_fd_sc_lp__nor2b_lp",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_m = logic_module(
-    "nor2b_m",
+    "sky130_fd_sc_lp__nor2b_m",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_0 = logic_module(
-    "nor3_0",
+    "sky130_fd_sc_lp__nor3_0",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_1 = logic_module(
-    "nor3_1",
+    "sky130_fd_sc_lp__nor3_1",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_2 = logic_module(
-    "nor3_2",
+    "sky130_fd_sc_lp__nor3_2",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_4 = logic_module(
-    "nor3_4",
+    "sky130_fd_sc_lp__nor3_4",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_lp = logic_module(
-    "nor3_lp",
+    "sky130_fd_sc_lp__nor3_lp",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_m = logic_module(
-    "nor3_m",
+    "sky130_fd_sc_lp__nor3_m",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_1 = logic_module(
-    "nor3b_1",
+    "sky130_fd_sc_lp__nor3b_1",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_2 = logic_module(
-    "nor3b_2",
+    "sky130_fd_sc_lp__nor3b_2",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_4 = logic_module(
-    "nor3b_4",
+    "sky130_fd_sc_lp__nor3b_4",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_lp = logic_module(
-    "nor3b_lp",
+    "sky130_fd_sc_lp__nor3b_lp",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_m = logic_module(
-    "nor3b_m",
+    "sky130_fd_sc_lp__nor3b_m",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_0 = logic_module(
-    "nor4_0",
+    "sky130_fd_sc_lp__nor4_0",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_1 = logic_module(
-    "nor4_1",
+    "sky130_fd_sc_lp__nor4_1",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_2 = logic_module(
-    "nor4_2",
+    "sky130_fd_sc_lp__nor4_2",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_4 = logic_module(
-    "nor4_4",
+    "sky130_fd_sc_lp__nor4_4",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_lp = logic_module(
-    "nor4_lp",
+    "sky130_fd_sc_lp__nor4_lp",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_m = logic_module(
-    "nor4_m",
+    "sky130_fd_sc_lp__nor4_m",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_1 = logic_module(
-    "nor4b_1",
+    "sky130_fd_sc_lp__nor4b_1",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_2 = logic_module(
-    "nor4b_2",
+    "sky130_fd_sc_lp__nor4b_2",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_4 = logic_module(
-    "nor4b_4",
+    "sky130_fd_sc_lp__nor4b_4",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_lp = logic_module(
-    "nor4b_lp",
+    "sky130_fd_sc_lp__nor4b_lp",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_m = logic_module(
-    "nor4b_m",
+    "sky130_fd_sc_lp__nor4b_m",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_1 = logic_module(
-    "nor4bb_1",
+    "sky130_fd_sc_lp__nor4bb_1",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_2 = logic_module(
-    "nor4bb_2",
+    "sky130_fd_sc_lp__nor4bb_2",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_4 = logic_module(
-    "nor4bb_4",
+    "sky130_fd_sc_lp__nor4bb_4",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_lp = logic_module(
-    "nor4bb_lp",
+    "sky130_fd_sc_lp__nor4bb_lp",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_m = logic_module(
-    "nor4bb_m",
+    "sky130_fd_sc_lp__nor4bb_m",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2a_0 = logic_module(
-    "o2bb2a_0",
+    "sky130_fd_sc_lp__o2bb2a_0",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_1 = logic_module(
-    "o2bb2a_1",
+    "sky130_fd_sc_lp__o2bb2a_1",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_2 = logic_module(
-    "o2bb2a_2",
+    "sky130_fd_sc_lp__o2bb2a_2",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_4 = logic_module(
-    "o2bb2a_4",
+    "sky130_fd_sc_lp__o2bb2a_4",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_lp = logic_module(
-    "o2bb2a_lp",
+    "sky130_fd_sc_lp__o2bb2a_lp",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_m = logic_module(
-    "o2bb2a_m",
+    "sky130_fd_sc_lp__o2bb2a_m",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2ai_0 = logic_module(
-    "o2bb2ai_0",
+    "sky130_fd_sc_lp__o2bb2ai_0",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_1 = logic_module(
-    "o2bb2ai_1",
+    "sky130_fd_sc_lp__o2bb2ai_1",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_2 = logic_module(
-    "o2bb2ai_2",
+    "sky130_fd_sc_lp__o2bb2ai_2",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_4 = logic_module(
-    "o2bb2ai_4",
+    "sky130_fd_sc_lp__o2bb2ai_4",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_lp = logic_module(
-    "o2bb2ai_lp",
+    "sky130_fd_sc_lp__o2bb2ai_lp",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_m = logic_module(
-    "o2bb2ai_m",
+    "sky130_fd_sc_lp__o2bb2ai_m",
     "Low Power",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21a_0 = logic_module(
-    "o21a_0",
+    "sky130_fd_sc_lp__o21a_0",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_1 = logic_module(
-    "o21a_1",
+    "sky130_fd_sc_lp__o21a_1",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_2 = logic_module(
-    "o21a_2",
+    "sky130_fd_sc_lp__o21a_2",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_4 = logic_module(
-    "o21a_4",
+    "sky130_fd_sc_lp__o21a_4",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_lp = logic_module(
-    "o21a_lp",
+    "sky130_fd_sc_lp__o21a_lp",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_m = logic_module(
-    "o21a_m",
+    "sky130_fd_sc_lp__o21a_m",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ai_0 = logic_module(
-    "o21ai_0",
+    "sky130_fd_sc_lp__o21ai_0",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_1 = logic_module(
-    "o21ai_1",
+    "sky130_fd_sc_lp__o21ai_1",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_2 = logic_module(
-    "o21ai_2",
+    "sky130_fd_sc_lp__o21ai_2",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_4 = logic_module(
-    "o21ai_4",
+    "sky130_fd_sc_lp__o21ai_4",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_lp = logic_module(
-    "o21ai_lp",
+    "sky130_fd_sc_lp__o21ai_lp",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_m = logic_module(
-    "o21ai_m",
+    "sky130_fd_sc_lp__o21ai_m",
     "Low Power",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ba_0 = logic_module(
-    "o21ba_0",
+    "sky130_fd_sc_lp__o21ba_0",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_1 = logic_module(
-    "o21ba_1",
+    "sky130_fd_sc_lp__o21ba_1",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_2 = logic_module(
-    "o21ba_2",
+    "sky130_fd_sc_lp__o21ba_2",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_4 = logic_module(
-    "o21ba_4",
+    "sky130_fd_sc_lp__o21ba_4",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_lp = logic_module(
-    "o21ba_lp",
+    "sky130_fd_sc_lp__o21ba_lp",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_m = logic_module(
-    "o21ba_m",
+    "sky130_fd_sc_lp__o21ba_m",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21bai_0 = logic_module(
-    "o21bai_0",
+    "sky130_fd_sc_lp__o21bai_0",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_1 = logic_module(
-    "o21bai_1",
+    "sky130_fd_sc_lp__o21bai_1",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_2 = logic_module(
-    "o21bai_2",
+    "sky130_fd_sc_lp__o21bai_2",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_4 = logic_module(
-    "o21bai_4",
+    "sky130_fd_sc_lp__o21bai_4",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_lp = logic_module(
-    "o21bai_lp",
+    "sky130_fd_sc_lp__o21bai_lp",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_m = logic_module(
-    "o21bai_m",
+    "sky130_fd_sc_lp__o21bai_m",
     "Low Power",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22a_0 = logic_module(
-    "o22a_0",
+    "sky130_fd_sc_lp__o22a_0",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_1 = logic_module(
-    "o22a_1",
+    "sky130_fd_sc_lp__o22a_1",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_2 = logic_module(
-    "o22a_2",
+    "sky130_fd_sc_lp__o22a_2",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_4 = logic_module(
-    "o22a_4",
+    "sky130_fd_sc_lp__o22a_4",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_lp = logic_module(
-    "o22a_lp",
+    "sky130_fd_sc_lp__o22a_lp",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_m = logic_module(
-    "o22a_m",
+    "sky130_fd_sc_lp__o22a_m",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22ai_0 = logic_module(
-    "o22ai_0",
+    "sky130_fd_sc_lp__o22ai_0",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_1 = logic_module(
-    "o22ai_1",
+    "sky130_fd_sc_lp__o22ai_1",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_2 = logic_module(
-    "o22ai_2",
+    "sky130_fd_sc_lp__o22ai_2",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_4 = logic_module(
-    "o22ai_4",
+    "sky130_fd_sc_lp__o22ai_4",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_lp = logic_module(
-    "o22ai_lp",
+    "sky130_fd_sc_lp__o22ai_lp",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_m = logic_module(
-    "o22ai_m",
+    "sky130_fd_sc_lp__o22ai_m",
     "Low Power",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31a_0 = logic_module(
-    "o31a_0",
+    "sky130_fd_sc_lp__o31a_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_1 = logic_module(
-    "o31a_1",
+    "sky130_fd_sc_lp__o31a_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_2 = logic_module(
-    "o31a_2",
+    "sky130_fd_sc_lp__o31a_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_4 = logic_module(
-    "o31a_4",
+    "sky130_fd_sc_lp__o31a_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_lp = logic_module(
-    "o31a_lp",
+    "sky130_fd_sc_lp__o31a_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_m = logic_module(
-    "o31a_m",
+    "sky130_fd_sc_lp__o31a_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31ai_0 = logic_module(
-    "o31ai_0",
+    "sky130_fd_sc_lp__o31ai_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_1 = logic_module(
-    "o31ai_1",
+    "sky130_fd_sc_lp__o31ai_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_2 = logic_module(
-    "o31ai_2",
+    "sky130_fd_sc_lp__o31ai_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_4 = logic_module(
-    "o31ai_4",
+    "sky130_fd_sc_lp__o31ai_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_lp = logic_module(
-    "o31ai_lp",
+    "sky130_fd_sc_lp__o31ai_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_m = logic_module(
-    "o31ai_m",
+    "sky130_fd_sc_lp__o31ai_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32a_0 = logic_module(
-    "o32a_0",
+    "sky130_fd_sc_lp__o32a_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_1 = logic_module(
-    "o32a_1",
+    "sky130_fd_sc_lp__o32a_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_2 = logic_module(
-    "o32a_2",
+    "sky130_fd_sc_lp__o32a_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_4 = logic_module(
-    "o32a_4",
+    "sky130_fd_sc_lp__o32a_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_lp = logic_module(
-    "o32a_lp",
+    "sky130_fd_sc_lp__o32a_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_m = logic_module(
-    "o32a_m",
+    "sky130_fd_sc_lp__o32a_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32ai_0 = logic_module(
-    "o32ai_0",
+    "sky130_fd_sc_lp__o32ai_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_1 = logic_module(
-    "o32ai_1",
+    "sky130_fd_sc_lp__o32ai_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_2 = logic_module(
-    "o32ai_2",
+    "sky130_fd_sc_lp__o32ai_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_4 = logic_module(
-    "o32ai_4",
+    "sky130_fd_sc_lp__o32ai_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_lp = logic_module(
-    "o32ai_lp",
+    "sky130_fd_sc_lp__o32ai_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_m = logic_module(
-    "o32ai_m",
+    "sky130_fd_sc_lp__o32ai_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41a_0 = logic_module(
-    "o41a_0",
+    "sky130_fd_sc_lp__o41a_0",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_1 = logic_module(
-    "o41a_1",
+    "sky130_fd_sc_lp__o41a_1",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_2 = logic_module(
-    "o41a_2",
+    "sky130_fd_sc_lp__o41a_2",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_4 = logic_module(
-    "o41a_4",
+    "sky130_fd_sc_lp__o41a_4",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_lp = logic_module(
-    "o41a_lp",
+    "sky130_fd_sc_lp__o41a_lp",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_m = logic_module(
-    "o41a_m",
+    "sky130_fd_sc_lp__o41a_m",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41ai_0 = logic_module(
-    "o41ai_0",
+    "sky130_fd_sc_lp__o41ai_0",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_1 = logic_module(
-    "o41ai_1",
+    "sky130_fd_sc_lp__o41ai_1",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_2 = logic_module(
-    "o41ai_2",
+    "sky130_fd_sc_lp__o41ai_2",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_4 = logic_module(
-    "o41ai_4",
+    "sky130_fd_sc_lp__o41ai_4",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_lp = logic_module(
-    "o41ai_lp",
+    "sky130_fd_sc_lp__o41ai_lp",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_m = logic_module(
-    "o41ai_m",
+    "sky130_fd_sc_lp__o41ai_m",
     "Low Power",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211a_0 = logic_module(
-    "o211a_0",
+    "sky130_fd_sc_lp__o211a_0",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_1 = logic_module(
-    "o211a_1",
+    "sky130_fd_sc_lp__o211a_1",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_2 = logic_module(
-    "o211a_2",
+    "sky130_fd_sc_lp__o211a_2",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_4 = logic_module(
-    "o211a_4",
+    "sky130_fd_sc_lp__o211a_4",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_lp = logic_module(
-    "o211a_lp",
+    "sky130_fd_sc_lp__o211a_lp",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_m = logic_module(
-    "o211a_m",
+    "sky130_fd_sc_lp__o211a_m",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211ai_0 = logic_module(
-    "o211ai_0",
+    "sky130_fd_sc_lp__o211ai_0",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_1 = logic_module(
-    "o211ai_1",
+    "sky130_fd_sc_lp__o211ai_1",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_2 = logic_module(
-    "o211ai_2",
+    "sky130_fd_sc_lp__o211ai_2",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_4 = logic_module(
-    "o211ai_4",
+    "sky130_fd_sc_lp__o211ai_4",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_lp = logic_module(
-    "o211ai_lp",
+    "sky130_fd_sc_lp__o211ai_lp",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_m = logic_module(
-    "o211ai_m",
+    "sky130_fd_sc_lp__o211ai_m",
     "Low Power",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221a_0 = logic_module(
-    "o221a_0",
+    "sky130_fd_sc_lp__o221a_0",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_1 = logic_module(
-    "o221a_1",
+    "sky130_fd_sc_lp__o221a_1",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_2 = logic_module(
-    "o221a_2",
+    "sky130_fd_sc_lp__o221a_2",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_4 = logic_module(
-    "o221a_4",
+    "sky130_fd_sc_lp__o221a_4",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_lp = logic_module(
-    "o221a_lp",
+    "sky130_fd_sc_lp__o221a_lp",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_m = logic_module(
-    "o221a_m",
+    "sky130_fd_sc_lp__o221a_m",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221ai_0 = logic_module(
-    "o221ai_0",
+    "sky130_fd_sc_lp__o221ai_0",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_1 = logic_module(
-    "o221ai_1",
+    "sky130_fd_sc_lp__o221ai_1",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_2 = logic_module(
-    "o221ai_2",
+    "sky130_fd_sc_lp__o221ai_2",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_4 = logic_module(
-    "o221ai_4",
+    "sky130_fd_sc_lp__o221ai_4",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_lp = logic_module(
-    "o221ai_lp",
+    "sky130_fd_sc_lp__o221ai_lp",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_m = logic_module(
-    "o221ai_m",
+    "sky130_fd_sc_lp__o221ai_m",
     "Low Power",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311a_0 = logic_module(
-    "o311a_0",
+    "sky130_fd_sc_lp__o311a_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_1 = logic_module(
-    "o311a_1",
+    "sky130_fd_sc_lp__o311a_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_2 = logic_module(
-    "o311a_2",
+    "sky130_fd_sc_lp__o311a_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_4 = logic_module(
-    "o311a_4",
+    "sky130_fd_sc_lp__o311a_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_lp = logic_module(
-    "o311a_lp",
+    "sky130_fd_sc_lp__o311a_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_m = logic_module(
-    "o311a_m",
+    "sky130_fd_sc_lp__o311a_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311ai_0 = logic_module(
-    "o311ai_0",
+    "sky130_fd_sc_lp__o311ai_0",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_1 = logic_module(
-    "o311ai_1",
+    "sky130_fd_sc_lp__o311ai_1",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_2 = logic_module(
-    "o311ai_2",
+    "sky130_fd_sc_lp__o311ai_2",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_4 = logic_module(
-    "o311ai_4",
+    "sky130_fd_sc_lp__o311ai_4",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_lp = logic_module(
-    "o311ai_lp",
+    "sky130_fd_sc_lp__o311ai_lp",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_m = logic_module(
-    "o311ai_m",
+    "sky130_fd_sc_lp__o311ai_m",
     "Low Power",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111a_0 = logic_module(
-    "o2111a_0",
+    "sky130_fd_sc_lp__o2111a_0",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_1 = logic_module(
-    "o2111a_1",
+    "sky130_fd_sc_lp__o2111a_1",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_2 = logic_module(
-    "o2111a_2",
+    "sky130_fd_sc_lp__o2111a_2",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_4 = logic_module(
-    "o2111a_4",
+    "sky130_fd_sc_lp__o2111a_4",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_lp = logic_module(
-    "o2111a_lp",
+    "sky130_fd_sc_lp__o2111a_lp",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_m = logic_module(
-    "o2111a_m",
+    "sky130_fd_sc_lp__o2111a_m",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111ai_0 = logic_module(
-    "o2111ai_0",
+    "sky130_fd_sc_lp__o2111ai_0",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_1 = logic_module(
-    "o2111ai_1",
+    "sky130_fd_sc_lp__o2111ai_1",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_2 = logic_module(
-    "o2111ai_2",
+    "sky130_fd_sc_lp__o2111ai_2",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_4 = logic_module(
-    "o2111ai_4",
+    "sky130_fd_sc_lp__o2111ai_4",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_lp = logic_module(
-    "o2111ai_lp",
+    "sky130_fd_sc_lp__o2111ai_lp",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_m = logic_module(
-    "o2111ai_m",
+    "sky130_fd_sc_lp__o2111ai_m",
     "Low Power",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 or2_0 = logic_module(
-    "or2_0",
+    "sky130_fd_sc_lp__or2_0",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_1 = logic_module(
-    "or2_1",
+    "sky130_fd_sc_lp__or2_1",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_2 = logic_module(
-    "or2_2",
+    "sky130_fd_sc_lp__or2_2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_4 = logic_module(
-    "or2_4",
+    "sky130_fd_sc_lp__or2_4",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_lp2 = logic_module(
-    "or2_lp2",
+    "sky130_fd_sc_lp__or2_lp2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_lp = logic_module(
-    "or2_lp",
+    "sky130_fd_sc_lp__or2_lp",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_m = logic_module(
-    "or2_m",
+    "sky130_fd_sc_lp__or2_m",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_1 = logic_module(
-    "or2b_1",
+    "sky130_fd_sc_lp__or2b_1",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_2 = logic_module(
-    "or2b_2",
+    "sky130_fd_sc_lp__or2b_2",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_4 = logic_module(
-    "or2b_4",
+    "sky130_fd_sc_lp__or2b_4",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_lp = logic_module(
-    "or2b_lp",
+    "sky130_fd_sc_lp__or2b_lp",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_m = logic_module(
-    "or2b_m",
+    "sky130_fd_sc_lp__or2b_m",
     "Low Power",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_0 = logic_module(
-    "or3_0",
+    "sky130_fd_sc_lp__or3_0",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_1 = logic_module(
-    "or3_1",
+    "sky130_fd_sc_lp__or3_1",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_2 = logic_module(
-    "or3_2",
+    "sky130_fd_sc_lp__or3_2",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_4 = logic_module(
-    "or3_4",
+    "sky130_fd_sc_lp__or3_4",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_lp = logic_module(
-    "or3_lp",
+    "sky130_fd_sc_lp__or3_lp",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_m = logic_module(
-    "or3_m",
+    "sky130_fd_sc_lp__or3_m",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_1 = logic_module(
-    "or3b_1",
+    "sky130_fd_sc_lp__or3b_1",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_2 = logic_module(
-    "or3b_2",
+    "sky130_fd_sc_lp__or3b_2",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_4 = logic_module(
-    "or3b_4",
+    "sky130_fd_sc_lp__or3b_4",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_lp = logic_module(
-    "or3b_lp",
+    "sky130_fd_sc_lp__or3b_lp",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_m = logic_module(
-    "or3b_m",
+    "sky130_fd_sc_lp__or3b_m",
     "Low Power",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_0 = logic_module(
-    "or4_0",
+    "sky130_fd_sc_lp__or4_0",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_1 = logic_module(
-    "or4_1",
+    "sky130_fd_sc_lp__or4_1",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_2 = logic_module(
-    "or4_2",
+    "sky130_fd_sc_lp__or4_2",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_4 = logic_module(
-    "or4_4",
+    "sky130_fd_sc_lp__or4_4",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_lp = logic_module(
-    "or4_lp",
+    "sky130_fd_sc_lp__or4_lp",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_m = logic_module(
-    "or4_m",
+    "sky130_fd_sc_lp__or4_m",
     "Low Power",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_1 = logic_module(
-    "or4b_1",
+    "sky130_fd_sc_lp__or4b_1",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_2 = logic_module(
-    "or4b_2",
+    "sky130_fd_sc_lp__or4b_2",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_4 = logic_module(
-    "or4b_4",
+    "sky130_fd_sc_lp__or4b_4",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_lp = logic_module(
-    "or4b_lp",
+    "sky130_fd_sc_lp__or4b_lp",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_m = logic_module(
-    "or4b_m",
+    "sky130_fd_sc_lp__or4b_m",
     "Low Power",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_1 = logic_module(
-    "or4bb_1",
+    "sky130_fd_sc_lp__or4bb_1",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_2 = logic_module(
-    "or4bb_2",
+    "sky130_fd_sc_lp__or4bb_2",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_4 = logic_module(
-    "or4bb_4",
+    "sky130_fd_sc_lp__or4bb_4",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_lp = logic_module(
-    "or4bb_lp",
+    "sky130_fd_sc_lp__or4bb_lp",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_m = logic_module(
-    "or4bb_m",
+    "sky130_fd_sc_lp__or4bb_m",
     "Low Power",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 sdfbbn_1 = logic_module(
-    "sdfbbn_1",
+    "sky130_fd_sc_lp__sdfbbn_1",
     "Low Power",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbn_2 = logic_module(
-    "sdfbbn_2",
+    "sky130_fd_sc_lp__sdfbbn_2",
     "Low Power",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbp_1 = logic_module(
-    "sdfbbp_1",
+    "sky130_fd_sc_lp__sdfbbp_1",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "SET_B", "VNB", "VPB", "Q", "Q_N"],
 )
 sdfrbp_1 = logic_module(
-    "sdfrbp_1",
+    "sky130_fd_sc_lp__sdfrbp_1",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrbp_2 = logic_module(
-    "sdfrbp_2",
+    "sky130_fd_sc_lp__sdfrbp_2",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrbp_lp = logic_module(
-    "sdfrbp_lp",
+    "sky130_fd_sc_lp__sdfrbp_lp",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrtn_1 = logic_module(
-    "sdfrtn_1",
+    "sky130_fd_sc_lp__sdfrtn_1",
     "Low Power",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_1 = logic_module(
-    "sdfrtp_1",
+    "sky130_fd_sc_lp__sdfrtp_1",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_2 = logic_module(
-    "sdfrtp_2",
+    "sky130_fd_sc_lp__sdfrtp_2",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_4 = logic_module(
-    "sdfrtp_4",
+    "sky130_fd_sc_lp__sdfrtp_4",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_lp2 = logic_module(
-    "sdfrtp_lp2",
+    "sky130_fd_sc_lp__sdfrtp_lp2",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_ov2 = logic_module(
-    "sdfrtp_ov2",
+    "sky130_fd_sc_lp__sdfrtp_ov2",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfsbp_1 = logic_module(
-    "sdfsbp_1",
+    "sky130_fd_sc_lp__sdfsbp_1",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfsbp_2 = logic_module(
-    "sdfsbp_2",
+    "sky130_fd_sc_lp__sdfsbp_2",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfsbp_lp = logic_module(
-    "sdfsbp_lp",
+    "sky130_fd_sc_lp__sdfsbp_lp",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfstp_1 = logic_module(
-    "sdfstp_1",
+    "sky130_fd_sc_lp__sdfstp_1",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_2 = logic_module(
-    "sdfstp_2",
+    "sky130_fd_sc_lp__sdfstp_2",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_4 = logic_module(
-    "sdfstp_4",
+    "sky130_fd_sc_lp__sdfstp_4",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_lp = logic_module(
-    "sdfstp_lp",
+    "sky130_fd_sc_lp__sdfstp_lp",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxbp_1 = logic_module(
-    "sdfxbp_1",
+    "sky130_fd_sc_lp__sdfxbp_1",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxbp_2 = logic_module(
-    "sdfxbp_2",
+    "sky130_fd_sc_lp__sdfxbp_2",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxbp_lp = logic_module(
-    "sdfxbp_lp",
+    "sky130_fd_sc_lp__sdfxbp_lp",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxtp_1 = logic_module(
-    "sdfxtp_1",
+    "sky130_fd_sc_lp__sdfxtp_1",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_2 = logic_module(
-    "sdfxtp_2",
+    "sky130_fd_sc_lp__sdfxtp_2",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_4 = logic_module(
-    "sdfxtp_4",
+    "sky130_fd_sc_lp__sdfxtp_4",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_lp = logic_module(
-    "sdfxtp_lp",
+    "sky130_fd_sc_lp__sdfxtp_lp",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdlclkp_1 = logic_module(
-    "sdlclkp_1",
+    "sky130_fd_sc_lp__sdlclkp_1",
     "Low Power",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_2 = logic_module(
-    "sdlclkp_2",
+    "sky130_fd_sc_lp__sdlclkp_2",
     "Low Power",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_4 = logic_module(
-    "sdlclkp_4",
+    "sky130_fd_sc_lp__sdlclkp_4",
     "Low Power",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_lp = logic_module(
-    "sdlclkp_lp",
+    "sky130_fd_sc_lp__sdlclkp_lp",
     "Low Power",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sleep_pargate_plv_7 = logic_module(
-    "sleep_pargate_plv_7",
+    "sky130_fd_sc_lp__sleep_pargate_plv_7",
     "Low Power",
     ["VIRTPWR", "VPWR", "SLEEP", "VPB"],
 )
 sleep_pargate_plv_14 = logic_module(
-    "sleep_pargate_plv_14",
+    "sky130_fd_sc_lp__sleep_pargate_plv_14",
     "Low Power",
     ["VIRTPWR", "VPWR", "SLEEP", "VPB"],
 )
 sleep_pargate_plv_21 = logic_module(
-    "sleep_pargate_plv_21",
+    "sky130_fd_sc_lp__sleep_pargate_plv_21",
     "Low Power",
     ["VIRTPWR", "VPWR", "SLEEP", "VPB"],
 )
 sleep_pargate_plv_28 = logic_module(
-    "sleep_pargate_plv_28",
+    "sky130_fd_sc_lp__sleep_pargate_plv_28",
     "Low Power",
     ["VIRTPWR", "VPWR", "SLEEP", "VPB"],
 )
 sleep_sergate_plv_14 = logic_module(
-    "sleep_sergate_plv_14",
+    "sky130_fd_sc_lp__sleep_sergate_plv_14",
     "Low Power",
     ["VIRTPWR", "VPWR", "SLEEP", "VPB"],
 )
 sleep_sergate_plv_21 = logic_module(
-    "sleep_sergate_plv_21",
+    "sky130_fd_sc_lp__sleep_sergate_plv_21",
     "Low Power",
     ["VIRTPWR", "VPWR", "SLEEP", "VPB"],
 )
 sleep_sergate_plv_28 = logic_module(
-    "sleep_sergate_plv_28",
+    "sky130_fd_sc_lp__sleep_sergate_plv_28",
     "Low Power",
     ["VIRTPWR", "VPWR", "SLEEP", "VPB"],
 )
 srdlrtp_1 = logic_module(
-    "srdlrtp_1",
+    "sky130_fd_sc_lp__srdlrtp_1",
     "Low Power",
     ["D", "GATE", "RESET_B", "SLEEP_B", "KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
 srdlstp_1 = logic_module(
-    "srdlstp_1",
+    "sky130_fd_sc_lp__srdlstp_1",
     "Low Power",
     ["D", "GATE", "SET_B", "SLEEP_B", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 srdlxtp_1 = logic_module(
-    "srdlxtp_1",
+    "sky130_fd_sc_lp__srdlxtp_1",
     "Low Power",
     ["D", "GATE", "SLEEP_B", "KAPWR", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sregrbp_1 = logic_module(
-    "sregrbp_1",
+    "sky130_fd_sc_lp__sregrbp_1",
     "Low Power",
     ["ASYNC", "CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sregsbp_1 = logic_module(
-    "sregsbp_1",
+    "sky130_fd_sc_lp__sregsbp_1",
     "Low Power",
     ["ASYNC", "CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 srsdfrtn_1 = logic_module(
-    "srsdfrtn_1",
+    "sky130_fd_sc_lp__srsdfrtn_1",
     "Low Power",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SLEEP_B", "KAPWR", "VGND", "VNB"],
 )
 srsdfrtp_1 = logic_module(
-    "srsdfrtp_1",
+    "sky130_fd_sc_lp__srsdfrtp_1",
     "Low Power",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "SLEEP_B", "KAPWR", "VGND", "VNB", "VPB"],
 )
 srsdfstp_1 = logic_module(
-    "srsdfstp_1",
+    "sky130_fd_sc_lp__srsdfstp_1",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SET_B", "SLEEP_B", "KAPWR", "VGND", "VNB", "VPB"],
 )
 srsdfxtp_1 = logic_module(
-    "srsdfxtp_1",
+    "sky130_fd_sc_lp__srsdfxtp_1",
     "Low Power",
     ["CLK", "D", "SCD", "SCE", "SLEEP_B", "KAPWR", "VGND", "VNB", "VPB", "VPWR"],
 )
-tap_1 = logic_module("tap_1", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-tap_2 = logic_module("tap_2", "Low Power", ["VGND", "VNB", "VPB", "VPWR"])
-tapvgnd2_1 = logic_module("tapvgnd2_1", "Low Power", ["VGND", "VPB", "VPWR"])
-tapvgnd_1 = logic_module("tapvgnd_1", "Low Power", ["VGND", "VPB", "VPWR"])
-tapvpwrvgnd_1 = logic_module("tapvpwrvgnd_1", "Low Power", ["VGND", "VPWR"])
+tap_1 = logic_module(
+    "sky130_fd_sc_lp__tap_1", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tap_2 = logic_module(
+    "sky130_fd_sc_lp__tap_2", "Low Power", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tapvgnd2_1 = logic_module(
+    "sky130_fd_sc_lp__tapvgnd2_1", "Low Power", ["VGND", "VPB", "VPWR"]
+)
+tapvgnd_1 = logic_module(
+    "sky130_fd_sc_lp__tapvgnd_1", "Low Power", ["VGND", "VPB", "VPWR"]
+)
+tapvpwrvgnd_1 = logic_module(
+    "sky130_fd_sc_lp__tapvpwrvgnd_1", "Low Power", ["VGND", "VPWR"]
+)
 xnor2_0 = logic_module(
-    "xnor2_0",
+    "sky130_fd_sc_lp__xnor2_0",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_1 = logic_module(
-    "xnor2_1",
+    "sky130_fd_sc_lp__xnor2_1",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_2 = logic_module(
-    "xnor2_2",
+    "sky130_fd_sc_lp__xnor2_2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_4 = logic_module(
-    "xnor2_4",
+    "sky130_fd_sc_lp__xnor2_4",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_lp = logic_module(
-    "xnor2_lp",
+    "sky130_fd_sc_lp__xnor2_lp",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_m = logic_module(
-    "xnor2_m",
+    "sky130_fd_sc_lp__xnor2_m",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor3_1 = logic_module(
-    "xnor3_1",
+    "sky130_fd_sc_lp__xnor3_1",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_lp = logic_module(
-    "xnor3_lp",
+    "sky130_fd_sc_lp__xnor3_lp",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_0 = logic_module(
-    "xor2_0",
+    "sky130_fd_sc_lp__xor2_0",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_1 = logic_module(
-    "xor2_1",
+    "sky130_fd_sc_lp__xor2_1",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_2 = logic_module(
-    "xor2_2",
+    "sky130_fd_sc_lp__xor2_2",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_4 = logic_module(
-    "xor2_4",
+    "sky130_fd_sc_lp__xor2_4",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_lp = logic_module(
-    "xor2_lp",
+    "sky130_fd_sc_lp__xor2_lp",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_m = logic_module(
-    "xor2_m",
+    "sky130_fd_sc_lp__xor2_m",
     "Low Power",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_1 = logic_module(
-    "xor3_1",
+    "sky130_fd_sc_lp__xor3_1",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_lp = logic_module(
-    "xor3_lp",
+    "sky130_fd_sc_lp__xor3_lp",
     "Low Power",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )

--- a/pdks/Sky130/sky130_hdl21/digital_cells/low_speed.py
+++ b/pdks/Sky130/sky130_hdl21/digital_cells/low_speed.py
@@ -1,1670 +1,1726 @@
 from ..pdk_data import logic_module
 
 a2bb2o_1 = logic_module(
-    "a2bb2o_1",
+    "sky130_fd_sc_ls__a2bb2o_1",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_2 = logic_module(
-    "a2bb2o_2",
+    "sky130_fd_sc_ls__a2bb2o_2",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_4 = logic_module(
-    "a2bb2o_4",
+    "sky130_fd_sc_ls__a2bb2o_4",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2oi_1 = logic_module(
-    "a2bb2oi_1",
+    "sky130_fd_sc_ls__a2bb2oi_1",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_2 = logic_module(
-    "a2bb2oi_2",
+    "sky130_fd_sc_ls__a2bb2oi_2",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_4 = logic_module(
-    "a2bb2oi_4",
+    "sky130_fd_sc_ls__a2bb2oi_4",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21bo_1 = logic_module(
-    "a21bo_1",
+    "sky130_fd_sc_ls__a21bo_1",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_2 = logic_module(
-    "a21bo_2",
+    "sky130_fd_sc_ls__a21bo_2",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_4 = logic_module(
-    "a21bo_4",
+    "sky130_fd_sc_ls__a21bo_4",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21boi_1 = logic_module(
-    "a21boi_1",
+    "sky130_fd_sc_ls__a21boi_1",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_2 = logic_module(
-    "a21boi_2",
+    "sky130_fd_sc_ls__a21boi_2",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_4 = logic_module(
-    "a21boi_4",
+    "sky130_fd_sc_ls__a21boi_4",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21o_1 = logic_module(
-    "a21o_1",
+    "sky130_fd_sc_ls__a21o_1",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_2 = logic_module(
-    "a21o_2",
+    "sky130_fd_sc_ls__a21o_2",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_4 = logic_module(
-    "a21o_4",
+    "sky130_fd_sc_ls__a21o_4",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21oi_1 = logic_module(
-    "a21oi_1",
+    "sky130_fd_sc_ls__a21oi_1",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_2 = logic_module(
-    "a21oi_2",
+    "sky130_fd_sc_ls__a21oi_2",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_4 = logic_module(
-    "a21oi_4",
+    "sky130_fd_sc_ls__a21oi_4",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22o_1 = logic_module(
-    "a22o_1",
+    "sky130_fd_sc_ls__a22o_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_2 = logic_module(
-    "a22o_2",
+    "sky130_fd_sc_ls__a22o_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_4 = logic_module(
-    "a22o_4",
+    "sky130_fd_sc_ls__a22o_4",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22oi_1 = logic_module(
-    "a22oi_1",
+    "sky130_fd_sc_ls__a22oi_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_2 = logic_module(
-    "a22oi_2",
+    "sky130_fd_sc_ls__a22oi_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_4 = logic_module(
-    "a22oi_4",
+    "sky130_fd_sc_ls__a22oi_4",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31o_1 = logic_module(
-    "a31o_1",
+    "sky130_fd_sc_ls__a31o_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_2 = logic_module(
-    "a31o_2",
+    "sky130_fd_sc_ls__a31o_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_4 = logic_module(
-    "a31o_4",
+    "sky130_fd_sc_ls__a31o_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31oi_1 = logic_module(
-    "a31oi_1",
+    "sky130_fd_sc_ls__a31oi_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_2 = logic_module(
-    "a31oi_2",
+    "sky130_fd_sc_ls__a31oi_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_4 = logic_module(
-    "a31oi_4",
+    "sky130_fd_sc_ls__a31oi_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32o_1 = logic_module(
-    "a32o_1",
+    "sky130_fd_sc_ls__a32o_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_2 = logic_module(
-    "a32o_2",
+    "sky130_fd_sc_ls__a32o_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_4 = logic_module(
-    "a32o_4",
+    "sky130_fd_sc_ls__a32o_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32oi_1 = logic_module(
-    "a32oi_1",
+    "sky130_fd_sc_ls__a32oi_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_2 = logic_module(
-    "a32oi_2",
+    "sky130_fd_sc_ls__a32oi_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_4 = logic_module(
-    "a32oi_4",
+    "sky130_fd_sc_ls__a32oi_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41o_1 = logic_module(
-    "a41o_1",
+    "sky130_fd_sc_ls__a41o_1",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_2 = logic_module(
-    "a41o_2",
+    "sky130_fd_sc_ls__a41o_2",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_4 = logic_module(
-    "a41o_4",
+    "sky130_fd_sc_ls__a41o_4",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41oi_1 = logic_module(
-    "a41oi_1",
+    "sky130_fd_sc_ls__a41oi_1",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_2 = logic_module(
-    "a41oi_2",
+    "sky130_fd_sc_ls__a41oi_2",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_4 = logic_module(
-    "a41oi_4",
+    "sky130_fd_sc_ls__a41oi_4",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211o_1 = logic_module(
-    "a211o_1",
+    "sky130_fd_sc_ls__a211o_1",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_2 = logic_module(
-    "a211o_2",
+    "sky130_fd_sc_ls__a211o_2",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_4 = logic_module(
-    "a211o_4",
+    "sky130_fd_sc_ls__a211o_4",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211oi_1 = logic_module(
-    "a211oi_1",
+    "sky130_fd_sc_ls__a211oi_1",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_2 = logic_module(
-    "a211oi_2",
+    "sky130_fd_sc_ls__a211oi_2",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_4 = logic_module(
-    "a211oi_4",
+    "sky130_fd_sc_ls__a211oi_4",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221o_1 = logic_module(
-    "a221o_1",
+    "sky130_fd_sc_ls__a221o_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_2 = logic_module(
-    "a221o_2",
+    "sky130_fd_sc_ls__a221o_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_4 = logic_module(
-    "a221o_4",
+    "sky130_fd_sc_ls__a221o_4",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221oi_1 = logic_module(
-    "a221oi_1",
+    "sky130_fd_sc_ls__a221oi_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_2 = logic_module(
-    "a221oi_2",
+    "sky130_fd_sc_ls__a221oi_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_4 = logic_module(
-    "a221oi_4",
+    "sky130_fd_sc_ls__a221oi_4",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a222o_1 = logic_module(
-    "a222o_1",
+    "sky130_fd_sc_ls__a222o_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a222o_2 = logic_module(
-    "a222o_2",
+    "sky130_fd_sc_ls__a222o_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a222oi_1 = logic_module(
-    "a222oi_1",
+    "sky130_fd_sc_ls__a222oi_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a222oi_2 = logic_module(
-    "a222oi_2",
+    "sky130_fd_sc_ls__a222oi_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311o_1 = logic_module(
-    "a311o_1",
+    "sky130_fd_sc_ls__a311o_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_2 = logic_module(
-    "a311o_2",
+    "sky130_fd_sc_ls__a311o_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_4 = logic_module(
-    "a311o_4",
+    "sky130_fd_sc_ls__a311o_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311oi_1 = logic_module(
-    "a311oi_1",
+    "sky130_fd_sc_ls__a311oi_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_2 = logic_module(
-    "a311oi_2",
+    "sky130_fd_sc_ls__a311oi_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_4 = logic_module(
-    "a311oi_4",
+    "sky130_fd_sc_ls__a311oi_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111o_1 = logic_module(
-    "a2111o_1",
+    "sky130_fd_sc_ls__a2111o_1",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_2 = logic_module(
-    "a2111o_2",
+    "sky130_fd_sc_ls__a2111o_2",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_4 = logic_module(
-    "a2111o_4",
+    "sky130_fd_sc_ls__a2111o_4",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111oi_1 = logic_module(
-    "a2111oi_1",
+    "sky130_fd_sc_ls__a2111oi_1",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_2 = logic_module(
-    "a2111oi_2",
+    "sky130_fd_sc_ls__a2111oi_2",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_4 = logic_module(
-    "a2111oi_4",
+    "sky130_fd_sc_ls__a2111oi_4",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 and2_1 = logic_module(
-    "and2_1",
+    "sky130_fd_sc_ls__and2_1",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_2 = logic_module(
-    "and2_2",
+    "sky130_fd_sc_ls__and2_2",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_4 = logic_module(
-    "and2_4",
+    "sky130_fd_sc_ls__and2_4",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_1 = logic_module(
-    "and2b_1",
+    "sky130_fd_sc_ls__and2b_1",
     "Low Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_2 = logic_module(
-    "and2b_2",
+    "sky130_fd_sc_ls__and2b_2",
     "Low Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_4 = logic_module(
-    "and2b_4",
+    "sky130_fd_sc_ls__and2b_4",
     "Low Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_1 = logic_module(
-    "and3_1",
+    "sky130_fd_sc_ls__and3_1",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_2 = logic_module(
-    "and3_2",
+    "sky130_fd_sc_ls__and3_2",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_4 = logic_module(
-    "and3_4",
+    "sky130_fd_sc_ls__and3_4",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_1 = logic_module(
-    "and3b_1",
+    "sky130_fd_sc_ls__and3b_1",
     "Low Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_2 = logic_module(
-    "and3b_2",
+    "sky130_fd_sc_ls__and3b_2",
     "Low Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_4 = logic_module(
-    "and3b_4",
+    "sky130_fd_sc_ls__and3b_4",
     "Low Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_1 = logic_module(
-    "and4_1",
+    "sky130_fd_sc_ls__and4_1",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_2 = logic_module(
-    "and4_2",
+    "sky130_fd_sc_ls__and4_2",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_4 = logic_module(
-    "and4_4",
+    "sky130_fd_sc_ls__and4_4",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_1 = logic_module(
-    "and4b_1",
+    "sky130_fd_sc_ls__and4b_1",
     "Low Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_2 = logic_module(
-    "and4b_2",
+    "sky130_fd_sc_ls__and4b_2",
     "Low Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_4 = logic_module(
-    "and4b_4",
+    "sky130_fd_sc_ls__and4b_4",
     "Low Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_1 = logic_module(
-    "and4bb_1",
+    "sky130_fd_sc_ls__and4bb_1",
     "Low Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_2 = logic_module(
-    "and4bb_2",
+    "sky130_fd_sc_ls__and4bb_2",
     "Low Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_4 = logic_module(
-    "and4bb_4",
+    "sky130_fd_sc_ls__and4bb_4",
     "Low Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
-buf_1 = logic_module("buf_1", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_2 = logic_module("buf_2", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_4 = logic_module("buf_4", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_8 = logic_module("buf_8", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
-buf_16 = logic_module("buf_16", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"])
+buf_1 = logic_module(
+    "sky130_fd_sc_ls__buf_1", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_2 = logic_module(
+    "sky130_fd_sc_ls__buf_2", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_4 = logic_module(
+    "sky130_fd_sc_ls__buf_4", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_8 = logic_module(
+    "sky130_fd_sc_ls__buf_8", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
+buf_16 = logic_module(
+    "sky130_fd_sc_ls__buf_16", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "X"]
+)
 bufbuf_8 = logic_module(
-    "bufbuf_8",
+    "sky130_fd_sc_ls__bufbuf_8",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_16 = logic_module(
-    "bufbuf_16",
+    "sky130_fd_sc_ls__bufbuf_16",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufinv_8 = logic_module(
-    "bufinv_8",
+    "sky130_fd_sc_ls__bufinv_8",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 bufinv_16 = logic_module(
-    "bufinv_16",
+    "sky130_fd_sc_ls__bufinv_16",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkbuf_1 = logic_module(
-    "clkbuf_1",
+    "sky130_fd_sc_ls__clkbuf_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_2 = logic_module(
-    "clkbuf_2",
+    "sky130_fd_sc_ls__clkbuf_2",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_4 = logic_module(
-    "clkbuf_4",
+    "sky130_fd_sc_ls__clkbuf_4",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_8 = logic_module(
-    "clkbuf_8",
+    "sky130_fd_sc_ls__clkbuf_8",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_16 = logic_module(
-    "clkbuf_16",
+    "sky130_fd_sc_ls__clkbuf_16",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlyinv3sd1_1 = logic_module(
-    "clkdlyinv3sd1_1",
+    "sky130_fd_sc_ls__clkdlyinv3sd1_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv3sd2_1 = logic_module(
-    "clkdlyinv3sd2_1",
+    "sky130_fd_sc_ls__clkdlyinv3sd2_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv3sd3_1 = logic_module(
-    "clkdlyinv3sd3_1",
+    "sky130_fd_sc_ls__clkdlyinv3sd3_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd1_1 = logic_module(
-    "clkdlyinv5sd1_1",
+    "sky130_fd_sc_ls__clkdlyinv5sd1_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd2_1 = logic_module(
-    "clkdlyinv5sd2_1",
+    "sky130_fd_sc_ls__clkdlyinv5sd2_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd3_1 = logic_module(
-    "clkdlyinv5sd3_1",
+    "sky130_fd_sc_ls__clkdlyinv5sd3_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_1 = logic_module(
-    "clkinv_1",
+    "sky130_fd_sc_ls__clkinv_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_2 = logic_module(
-    "clkinv_2",
+    "sky130_fd_sc_ls__clkinv_2",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_4 = logic_module(
-    "clkinv_4",
+    "sky130_fd_sc_ls__clkinv_4",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_8 = logic_module(
-    "clkinv_8",
+    "sky130_fd_sc_ls__clkinv_8",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_16 = logic_module(
-    "clkinv_16",
+    "sky130_fd_sc_ls__clkinv_16",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 conb_1 = logic_module(
-    "conb_1",
+    "sky130_fd_sc_ls__conb_1",
     "Low Speed",
     ["VGND", "VNB", "VPB", "VPWR", "HI", "LO"],
 )
-decap_4 = logic_module("decap_4", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decap_8 = logic_module("decap_8", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decaphe_2 = logic_module("decaphe_2", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decaphe_3 = logic_module("decaphe_3", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decaphe_4 = logic_module("decaphe_4", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decaphe_6 = logic_module("decaphe_6", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decaphe_8 = logic_module("decaphe_8", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decaphe_18 = logic_module("decaphe_18", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decaphetap_2 = logic_module("decaphetap_2", "Low Speed", ["VGND", "VPB", "VPWR"])
+decap_4 = logic_module(
+    "sky130_fd_sc_ls__decap_4", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_8 = logic_module(
+    "sky130_fd_sc_ls__decap_8", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decaphe_2 = logic_module(
+    "sky130_fd_sc_ls__decaphe_2", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decaphe_3 = logic_module(
+    "sky130_fd_sc_ls__decaphe_3", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decaphe_4 = logic_module(
+    "sky130_fd_sc_ls__decaphe_4", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decaphe_6 = logic_module(
+    "sky130_fd_sc_ls__decaphe_6", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decaphe_8 = logic_module(
+    "sky130_fd_sc_ls__decaphe_8", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decaphe_18 = logic_module(
+    "sky130_fd_sc_ls__decaphe_18", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decaphetap_2 = logic_module(
+    "sky130_fd_sc_ls__decaphetap_2", "Low Speed", ["VGND", "VPB", "VPWR"]
+)
 dfbbn_1 = logic_module(
-    "dfbbn_1",
+    "sky130_fd_sc_ls__dfbbn_1",
     "Low Speed",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbn_2 = logic_module(
-    "dfbbn_2",
+    "sky130_fd_sc_ls__dfbbn_2",
     "Low Speed",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbp_1 = logic_module(
-    "dfbbp_1",
+    "sky130_fd_sc_ls__dfbbp_1",
     "Low Speed",
     ["CLK", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_1 = logic_module(
-    "dfrbp_1",
+    "sky130_fd_sc_ls__dfrbp_1",
     "Low Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_2 = logic_module(
-    "dfrbp_2",
+    "sky130_fd_sc_ls__dfrbp_2",
     "Low Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrtn_1 = logic_module(
-    "dfrtn_1",
+    "sky130_fd_sc_ls__dfrtn_1",
     "Low Speed",
     ["CLK_N", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_1 = logic_module(
-    "dfrtp_1",
+    "sky130_fd_sc_ls__dfrtp_1",
     "Low Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_2 = logic_module(
-    "dfrtp_2",
+    "sky130_fd_sc_ls__dfrtp_2",
     "Low Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_4 = logic_module(
-    "dfrtp_4",
+    "sky130_fd_sc_ls__dfrtp_4",
     "Low Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfsbp_1 = logic_module(
-    "dfsbp_1",
+    "sky130_fd_sc_ls__dfsbp_1",
     "Low Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfsbp_2 = logic_module(
-    "dfsbp_2",
+    "sky130_fd_sc_ls__dfsbp_2",
     "Low Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfstp_1 = logic_module(
-    "dfstp_1",
+    "sky130_fd_sc_ls__dfstp_1",
     "Low Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_2 = logic_module(
-    "dfstp_2",
+    "sky130_fd_sc_ls__dfstp_2",
     "Low Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_4 = logic_module(
-    "dfstp_4",
+    "sky130_fd_sc_ls__dfstp_4",
     "Low Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxbp_1 = logic_module(
-    "dfxbp_1",
+    "sky130_fd_sc_ls__dfxbp_1",
     "Low Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxbp_2 = logic_module(
-    "dfxbp_2",
+    "sky130_fd_sc_ls__dfxbp_2",
     "Low Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxtp_1 = logic_module(
-    "dfxtp_1",
+    "sky130_fd_sc_ls__dfxtp_1",
     "Low Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_2 = logic_module(
-    "dfxtp_2",
+    "sky130_fd_sc_ls__dfxtp_2",
     "Low Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_4 = logic_module(
-    "dfxtp_4",
+    "sky130_fd_sc_ls__dfxtp_4",
     "Low Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
-diode_2 = logic_module("diode_2", "Low Speed", ["DIODE", "VGND", "VNB", "VPB", "VPWR"])
+diode_2 = logic_module(
+    "sky130_fd_sc_ls__diode_2", "Low Speed", ["DIODE", "VGND", "VNB", "VPB", "VPWR"]
+)
 dlclkp_1 = logic_module(
-    "dlclkp_1",
+    "sky130_fd_sc_ls__dlclkp_1",
     "Low Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_2 = logic_module(
-    "dlclkp_2",
+    "sky130_fd_sc_ls__dlclkp_2",
     "Low Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_4 = logic_module(
-    "dlclkp_4",
+    "sky130_fd_sc_ls__dlclkp_4",
     "Low Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlrbn_1 = logic_module(
-    "dlrbn_1",
+    "sky130_fd_sc_ls__dlrbn_1",
     "Low Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbn_2 = logic_module(
-    "dlrbn_2",
+    "sky130_fd_sc_ls__dlrbn_2",
     "Low Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_1 = logic_module(
-    "dlrbp_1",
+    "sky130_fd_sc_ls__dlrbp_1",
     "Low Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_2 = logic_module(
-    "dlrbp_2",
+    "sky130_fd_sc_ls__dlrbp_2",
     "Low Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrtn_1 = logic_module(
-    "dlrtn_1",
+    "sky130_fd_sc_ls__dlrtn_1",
     "Low Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_2 = logic_module(
-    "dlrtn_2",
+    "sky130_fd_sc_ls__dlrtn_2",
     "Low Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_4 = logic_module(
-    "dlrtn_4",
+    "sky130_fd_sc_ls__dlrtn_4",
     "Low Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_1 = logic_module(
-    "dlrtp_1",
+    "sky130_fd_sc_ls__dlrtp_1",
     "Low Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_2 = logic_module(
-    "dlrtp_2",
+    "sky130_fd_sc_ls__dlrtp_2",
     "Low Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_4 = logic_module(
-    "dlrtp_4",
+    "sky130_fd_sc_ls__dlrtp_4",
     "Low Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxbn_1 = logic_module(
-    "dlxbn_1",
+    "sky130_fd_sc_ls__dlxbn_1",
     "Low Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbn_2 = logic_module(
-    "dlxbn_2",
+    "sky130_fd_sc_ls__dlxbn_2",
     "Low Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbp_1 = logic_module(
-    "dlxbp_1",
+    "sky130_fd_sc_ls__dlxbp_1",
     "Low Speed",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxtn_1 = logic_module(
-    "dlxtn_1",
+    "sky130_fd_sc_ls__dlxtn_1",
     "Low Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_2 = logic_module(
-    "dlxtn_2",
+    "sky130_fd_sc_ls__dlxtn_2",
     "Low Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_4 = logic_module(
-    "dlxtn_4",
+    "sky130_fd_sc_ls__dlxtn_4",
     "Low Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtp_1 = logic_module(
-    "dlxtp_1",
+    "sky130_fd_sc_ls__dlxtp_1",
     "Low Speed",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlygate4sd1_1 = logic_module(
-    "dlygate4sd1_1",
+    "sky130_fd_sc_ls__dlygate4sd1_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd2_1 = logic_module(
-    "dlygate4sd2_1",
+    "sky130_fd_sc_ls__dlygate4sd2_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd3_1 = logic_module(
-    "dlygate4sd3_1",
+    "sky130_fd_sc_ls__dlygate4sd3_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s2s_1 = logic_module(
-    "dlymetal6s2s_1",
+    "sky130_fd_sc_ls__dlymetal6s2s_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s4s_1 = logic_module(
-    "dlymetal6s4s_1",
+    "sky130_fd_sc_ls__dlymetal6s4s_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s6s_1 = logic_module(
-    "dlymetal6s6s_1",
+    "sky130_fd_sc_ls__dlymetal6s6s_1",
     "Low Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 ebufn_1 = logic_module(
-    "ebufn_1",
+    "sky130_fd_sc_ls__ebufn_1",
     "Low Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_2 = logic_module(
-    "ebufn_2",
+    "sky130_fd_sc_ls__ebufn_2",
     "Low Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_4 = logic_module(
-    "ebufn_4",
+    "sky130_fd_sc_ls__ebufn_4",
     "Low Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_8 = logic_module(
-    "ebufn_8",
+    "sky130_fd_sc_ls__ebufn_8",
     "Low Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 edfxbp_1 = logic_module(
-    "edfxbp_1",
+    "sky130_fd_sc_ls__edfxbp_1",
     "Low Speed",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 edfxtp_1 = logic_module(
-    "edfxtp_1",
+    "sky130_fd_sc_ls__edfxtp_1",
     "Low Speed",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 einvn_1 = logic_module(
-    "einvn_1",
+    "sky130_fd_sc_ls__einvn_1",
     "Low Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_2 = logic_module(
-    "einvn_2",
+    "sky130_fd_sc_ls__einvn_2",
     "Low Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_4 = logic_module(
-    "einvn_4",
+    "sky130_fd_sc_ls__einvn_4",
     "Low Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_8 = logic_module(
-    "einvn_8",
+    "sky130_fd_sc_ls__einvn_8",
     "Low Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_1 = logic_module(
-    "einvp_1",
+    "sky130_fd_sc_ls__einvp_1",
     "Low Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_2 = logic_module(
-    "einvp_2",
+    "sky130_fd_sc_ls__einvp_2",
     "Low Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_4 = logic_module(
-    "einvp_4",
+    "sky130_fd_sc_ls__einvp_4",
     "Low Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_8 = logic_module(
-    "einvp_8",
+    "sky130_fd_sc_ls__einvp_8",
     "Low Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 fa_1 = logic_module(
-    "fa_1",
+    "sky130_fd_sc_ls__fa_1",
     "Low Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_2 = logic_module(
-    "fa_2",
+    "sky130_fd_sc_ls__fa_2",
     "Low Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_4 = logic_module(
-    "fa_4",
+    "sky130_fd_sc_ls__fa_4",
     "Low Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_1 = logic_module(
-    "fah_1",
+    "sky130_fd_sc_ls__fah_1",
     "Low Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_2 = logic_module(
-    "fah_2",
+    "sky130_fd_sc_ls__fah_2",
     "Low Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_4 = logic_module(
-    "fah_4",
+    "sky130_fd_sc_ls__fah_4",
     "Low Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcin_1 = logic_module(
-    "fahcin_1",
+    "sky130_fd_sc_ls__fahcin_1",
     "Low Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcon_1 = logic_module(
-    "fahcon_1",
+    "sky130_fd_sc_ls__fahcon_1",
     "Low Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT_N", "SUM"],
 )
-fill_1 = logic_module("fill_1", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_2 = logic_module("fill_2", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_4 = logic_module("fill_4", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_8 = logic_module("fill_8", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_diode_2 = logic_module("fill_diode_2", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_diode_4 = logic_module("fill_diode_4", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_diode_8 = logic_module("fill_diode_8", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
+fill_1 = logic_module(
+    "sky130_fd_sc_ls__fill_1", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_2 = logic_module(
+    "sky130_fd_sc_ls__fill_2", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_4 = logic_module(
+    "sky130_fd_sc_ls__fill_4", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_8 = logic_module(
+    "sky130_fd_sc_ls__fill_8", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_diode_2 = logic_module(
+    "sky130_fd_sc_ls__fill_diode_2", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_diode_4 = logic_module(
+    "sky130_fd_sc_ls__fill_diode_4", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_diode_8 = logic_module(
+    "sky130_fd_sc_ls__fill_diode_8", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
 ha_1 = logic_module(
-    "ha_1",
+    "sky130_fd_sc_ls__ha_1",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_2 = logic_module(
-    "ha_2",
+    "sky130_fd_sc_ls__ha_2",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_4 = logic_module(
-    "ha_4",
+    "sky130_fd_sc_ls__ha_4",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
-inv_1 = logic_module("inv_1", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_2 = logic_module("inv_2", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_4 = logic_module("inv_4", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_8 = logic_module("inv_8", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-inv_16 = logic_module("inv_16", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"])
-latchupcell = logic_module("latchupcell", "Low Speed", ["VGND", "VPWR"])
+inv_1 = logic_module(
+    "sky130_fd_sc_ls__inv_1", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_2 = logic_module(
+    "sky130_fd_sc_ls__inv_2", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_4 = logic_module(
+    "sky130_fd_sc_ls__inv_4", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_8 = logic_module(
+    "sky130_fd_sc_ls__inv_8", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+inv_16 = logic_module(
+    "sky130_fd_sc_ls__inv_16", "Low Speed", ["A", "VGND", "VNB", "VPB", "VPWR", "Y"]
+)
+latchupcell = logic_module(
+    "sky130_fd_sc_ls__latchupcell", "Low Speed", ["VGND", "VPWR"]
+)
 maj3_1 = logic_module(
-    "maj3_1",
+    "sky130_fd_sc_ls__maj3_1",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_2 = logic_module(
-    "maj3_2",
+    "sky130_fd_sc_ls__maj3_2",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_4 = logic_module(
-    "maj3_4",
+    "sky130_fd_sc_ls__maj3_4",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_1 = logic_module(
-    "mux2_1",
+    "sky130_fd_sc_ls__mux2_1",
     "Low Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_2 = logic_module(
-    "mux2_2",
+    "sky130_fd_sc_ls__mux2_2",
     "Low Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_4 = logic_module(
-    "mux2_4",
+    "sky130_fd_sc_ls__mux2_4",
     "Low Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2i_1 = logic_module(
-    "mux2i_1",
+    "sky130_fd_sc_ls__mux2i_1",
     "Low Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_2 = logic_module(
-    "mux2i_2",
+    "sky130_fd_sc_ls__mux2i_2",
     "Low Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_4 = logic_module(
-    "mux2i_4",
+    "sky130_fd_sc_ls__mux2i_4",
     "Low Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux4_1 = logic_module(
-    "mux4_1",
+    "sky130_fd_sc_ls__mux4_1",
     "Low Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_2 = logic_module(
-    "mux4_2",
+    "sky130_fd_sc_ls__mux4_2",
     "Low Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_4 = logic_module(
-    "mux4_4",
+    "sky130_fd_sc_ls__mux4_4",
     "Low Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 nand2_1 = logic_module(
-    "nand2_1",
+    "sky130_fd_sc_ls__nand2_1",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_2 = logic_module(
-    "nand2_2",
+    "sky130_fd_sc_ls__nand2_2",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_4 = logic_module(
-    "nand2_4",
+    "sky130_fd_sc_ls__nand2_4",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_8 = logic_module(
-    "nand2_8",
+    "sky130_fd_sc_ls__nand2_8",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_1 = logic_module(
-    "nand2b_1",
+    "sky130_fd_sc_ls__nand2b_1",
     "Low Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_2 = logic_module(
-    "nand2b_2",
+    "sky130_fd_sc_ls__nand2b_2",
     "Low Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_4 = logic_module(
-    "nand2b_4",
+    "sky130_fd_sc_ls__nand2b_4",
     "Low Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_1 = logic_module(
-    "nand3_1",
+    "sky130_fd_sc_ls__nand3_1",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_2 = logic_module(
-    "nand3_2",
+    "sky130_fd_sc_ls__nand3_2",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_4 = logic_module(
-    "nand3_4",
+    "sky130_fd_sc_ls__nand3_4",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_1 = logic_module(
-    "nand3b_1",
+    "sky130_fd_sc_ls__nand3b_1",
     "Low Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_2 = logic_module(
-    "nand3b_2",
+    "sky130_fd_sc_ls__nand3b_2",
     "Low Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_4 = logic_module(
-    "nand3b_4",
+    "sky130_fd_sc_ls__nand3b_4",
     "Low Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_1 = logic_module(
-    "nand4_1",
+    "sky130_fd_sc_ls__nand4_1",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_2 = logic_module(
-    "nand4_2",
+    "sky130_fd_sc_ls__nand4_2",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_4 = logic_module(
-    "nand4_4",
+    "sky130_fd_sc_ls__nand4_4",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_1 = logic_module(
-    "nand4b_1",
+    "sky130_fd_sc_ls__nand4b_1",
     "Low Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_2 = logic_module(
-    "nand4b_2",
+    "sky130_fd_sc_ls__nand4b_2",
     "Low Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_4 = logic_module(
-    "nand4b_4",
+    "sky130_fd_sc_ls__nand4b_4",
     "Low Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_1 = logic_module(
-    "nand4bb_1",
+    "sky130_fd_sc_ls__nand4bb_1",
     "Low Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_2 = logic_module(
-    "nand4bb_2",
+    "sky130_fd_sc_ls__nand4bb_2",
     "Low Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_4 = logic_module(
-    "nand4bb_4",
+    "sky130_fd_sc_ls__nand4bb_4",
     "Low Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_1 = logic_module(
-    "nor2_1",
+    "sky130_fd_sc_ls__nor2_1",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_2 = logic_module(
-    "nor2_2",
+    "sky130_fd_sc_ls__nor2_2",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_4 = logic_module(
-    "nor2_4",
+    "sky130_fd_sc_ls__nor2_4",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_8 = logic_module(
-    "nor2_8",
+    "sky130_fd_sc_ls__nor2_8",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_1 = logic_module(
-    "nor2b_1",
+    "sky130_fd_sc_ls__nor2b_1",
     "Low Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_2 = logic_module(
-    "nor2b_2",
+    "sky130_fd_sc_ls__nor2b_2",
     "Low Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_4 = logic_module(
-    "nor2b_4",
+    "sky130_fd_sc_ls__nor2b_4",
     "Low Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_1 = logic_module(
-    "nor3_1",
+    "sky130_fd_sc_ls__nor3_1",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_2 = logic_module(
-    "nor3_2",
+    "sky130_fd_sc_ls__nor3_2",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_4 = logic_module(
-    "nor3_4",
+    "sky130_fd_sc_ls__nor3_4",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_1 = logic_module(
-    "nor3b_1",
+    "sky130_fd_sc_ls__nor3b_1",
     "Low Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_2 = logic_module(
-    "nor3b_2",
+    "sky130_fd_sc_ls__nor3b_2",
     "Low Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_4 = logic_module(
-    "nor3b_4",
+    "sky130_fd_sc_ls__nor3b_4",
     "Low Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_1 = logic_module(
-    "nor4_1",
+    "sky130_fd_sc_ls__nor4_1",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_2 = logic_module(
-    "nor4_2",
+    "sky130_fd_sc_ls__nor4_2",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_4 = logic_module(
-    "nor4_4",
+    "sky130_fd_sc_ls__nor4_4",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_1 = logic_module(
-    "nor4b_1",
+    "sky130_fd_sc_ls__nor4b_1",
     "Low Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_2 = logic_module(
-    "nor4b_2",
+    "sky130_fd_sc_ls__nor4b_2",
     "Low Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_4 = logic_module(
-    "nor4b_4",
+    "sky130_fd_sc_ls__nor4b_4",
     "Low Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_1 = logic_module(
-    "nor4bb_1",
+    "sky130_fd_sc_ls__nor4bb_1",
     "Low Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_2 = logic_module(
-    "nor4bb_2",
+    "sky130_fd_sc_ls__nor4bb_2",
     "Low Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_4 = logic_module(
-    "nor4bb_4",
+    "sky130_fd_sc_ls__nor4bb_4",
     "Low Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2a_1 = logic_module(
-    "o2bb2a_1",
+    "sky130_fd_sc_ls__o2bb2a_1",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_2 = logic_module(
-    "o2bb2a_2",
+    "sky130_fd_sc_ls__o2bb2a_2",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_4 = logic_module(
-    "o2bb2a_4",
+    "sky130_fd_sc_ls__o2bb2a_4",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2ai_1 = logic_module(
-    "o2bb2ai_1",
+    "sky130_fd_sc_ls__o2bb2ai_1",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_2 = logic_module(
-    "o2bb2ai_2",
+    "sky130_fd_sc_ls__o2bb2ai_2",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_4 = logic_module(
-    "o2bb2ai_4",
+    "sky130_fd_sc_ls__o2bb2ai_4",
     "Low Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21a_1 = logic_module(
-    "o21a_1",
+    "sky130_fd_sc_ls__o21a_1",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_2 = logic_module(
-    "o21a_2",
+    "sky130_fd_sc_ls__o21a_2",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_4 = logic_module(
-    "o21a_4",
+    "sky130_fd_sc_ls__o21a_4",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ai_1 = logic_module(
-    "o21ai_1",
+    "sky130_fd_sc_ls__o21ai_1",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_2 = logic_module(
-    "o21ai_2",
+    "sky130_fd_sc_ls__o21ai_2",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_4 = logic_module(
-    "o21ai_4",
+    "sky130_fd_sc_ls__o21ai_4",
     "Low Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ba_1 = logic_module(
-    "o21ba_1",
+    "sky130_fd_sc_ls__o21ba_1",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_2 = logic_module(
-    "o21ba_2",
+    "sky130_fd_sc_ls__o21ba_2",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_4 = logic_module(
-    "o21ba_4",
+    "sky130_fd_sc_ls__o21ba_4",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21bai_1 = logic_module(
-    "o21bai_1",
+    "sky130_fd_sc_ls__o21bai_1",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_2 = logic_module(
-    "o21bai_2",
+    "sky130_fd_sc_ls__o21bai_2",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_4 = logic_module(
-    "o21bai_4",
+    "sky130_fd_sc_ls__o21bai_4",
     "Low Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22a_1 = logic_module(
-    "o22a_1",
+    "sky130_fd_sc_ls__o22a_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_2 = logic_module(
-    "o22a_2",
+    "sky130_fd_sc_ls__o22a_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_4 = logic_module(
-    "o22a_4",
+    "sky130_fd_sc_ls__o22a_4",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22ai_1 = logic_module(
-    "o22ai_1",
+    "sky130_fd_sc_ls__o22ai_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_2 = logic_module(
-    "o22ai_2",
+    "sky130_fd_sc_ls__o22ai_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_4 = logic_module(
-    "o22ai_4",
+    "sky130_fd_sc_ls__o22ai_4",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31a_1 = logic_module(
-    "o31a_1",
+    "sky130_fd_sc_ls__o31a_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_2 = logic_module(
-    "o31a_2",
+    "sky130_fd_sc_ls__o31a_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_4 = logic_module(
-    "o31a_4",
+    "sky130_fd_sc_ls__o31a_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31ai_1 = logic_module(
-    "o31ai_1",
+    "sky130_fd_sc_ls__o31ai_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_2 = logic_module(
-    "o31ai_2",
+    "sky130_fd_sc_ls__o31ai_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_4 = logic_module(
-    "o31ai_4",
+    "sky130_fd_sc_ls__o31ai_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32a_1 = logic_module(
-    "o32a_1",
+    "sky130_fd_sc_ls__o32a_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_2 = logic_module(
-    "o32a_2",
+    "sky130_fd_sc_ls__o32a_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_4 = logic_module(
-    "o32a_4",
+    "sky130_fd_sc_ls__o32a_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32ai_1 = logic_module(
-    "o32ai_1",
+    "sky130_fd_sc_ls__o32ai_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_2 = logic_module(
-    "o32ai_2",
+    "sky130_fd_sc_ls__o32ai_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_4 = logic_module(
-    "o32ai_4",
+    "sky130_fd_sc_ls__o32ai_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41a_1 = logic_module(
-    "o41a_1",
+    "sky130_fd_sc_ls__o41a_1",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_2 = logic_module(
-    "o41a_2",
+    "sky130_fd_sc_ls__o41a_2",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_4 = logic_module(
-    "o41a_4",
+    "sky130_fd_sc_ls__o41a_4",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41ai_1 = logic_module(
-    "o41ai_1",
+    "sky130_fd_sc_ls__o41ai_1",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_2 = logic_module(
-    "o41ai_2",
+    "sky130_fd_sc_ls__o41ai_2",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_4 = logic_module(
-    "o41ai_4",
+    "sky130_fd_sc_ls__o41ai_4",
     "Low Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211a_1 = logic_module(
-    "o211a_1",
+    "sky130_fd_sc_ls__o211a_1",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_2 = logic_module(
-    "o211a_2",
+    "sky130_fd_sc_ls__o211a_2",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_4 = logic_module(
-    "o211a_4",
+    "sky130_fd_sc_ls__o211a_4",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211ai_1 = logic_module(
-    "o211ai_1",
+    "sky130_fd_sc_ls__o211ai_1",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_2 = logic_module(
-    "o211ai_2",
+    "sky130_fd_sc_ls__o211ai_2",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_4 = logic_module(
-    "o211ai_4",
+    "sky130_fd_sc_ls__o211ai_4",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221a_1 = logic_module(
-    "o221a_1",
+    "sky130_fd_sc_ls__o221a_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_2 = logic_module(
-    "o221a_2",
+    "sky130_fd_sc_ls__o221a_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_4 = logic_module(
-    "o221a_4",
+    "sky130_fd_sc_ls__o221a_4",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221ai_1 = logic_module(
-    "o221ai_1",
+    "sky130_fd_sc_ls__o221ai_1",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_2 = logic_module(
-    "o221ai_2",
+    "sky130_fd_sc_ls__o221ai_2",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_4 = logic_module(
-    "o221ai_4",
+    "sky130_fd_sc_ls__o221ai_4",
     "Low Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311a_1 = logic_module(
-    "o311a_1",
+    "sky130_fd_sc_ls__o311a_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_2 = logic_module(
-    "o311a_2",
+    "sky130_fd_sc_ls__o311a_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_4 = logic_module(
-    "o311a_4",
+    "sky130_fd_sc_ls__o311a_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311ai_1 = logic_module(
-    "o311ai_1",
+    "sky130_fd_sc_ls__o311ai_1",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_2 = logic_module(
-    "o311ai_2",
+    "sky130_fd_sc_ls__o311ai_2",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_4 = logic_module(
-    "o311ai_4",
+    "sky130_fd_sc_ls__o311ai_4",
     "Low Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111a_1 = logic_module(
-    "o2111a_1",
+    "sky130_fd_sc_ls__o2111a_1",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_2 = logic_module(
-    "o2111a_2",
+    "sky130_fd_sc_ls__o2111a_2",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_4 = logic_module(
-    "o2111a_4",
+    "sky130_fd_sc_ls__o2111a_4",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111ai_1 = logic_module(
-    "o2111ai_1",
+    "sky130_fd_sc_ls__o2111ai_1",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_2 = logic_module(
-    "o2111ai_2",
+    "sky130_fd_sc_ls__o2111ai_2",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_4 = logic_module(
-    "o2111ai_4",
+    "sky130_fd_sc_ls__o2111ai_4",
     "Low Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 or2_1 = logic_module(
-    "or2_1",
+    "sky130_fd_sc_ls__or2_1",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_2 = logic_module(
-    "or2_2",
+    "sky130_fd_sc_ls__or2_2",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_4 = logic_module(
-    "or2_4",
+    "sky130_fd_sc_ls__or2_4",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_1 = logic_module(
-    "or2b_1",
+    "sky130_fd_sc_ls__or2b_1",
     "Low Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_2 = logic_module(
-    "or2b_2",
+    "sky130_fd_sc_ls__or2b_2",
     "Low Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_4 = logic_module(
-    "or2b_4",
+    "sky130_fd_sc_ls__or2b_4",
     "Low Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_1 = logic_module(
-    "or3_1",
+    "sky130_fd_sc_ls__or3_1",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_2 = logic_module(
-    "or3_2",
+    "sky130_fd_sc_ls__or3_2",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_4 = logic_module(
-    "or3_4",
+    "sky130_fd_sc_ls__or3_4",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_1 = logic_module(
-    "or3b_1",
+    "sky130_fd_sc_ls__or3b_1",
     "Low Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_2 = logic_module(
-    "or3b_2",
+    "sky130_fd_sc_ls__or3b_2",
     "Low Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_4 = logic_module(
-    "or3b_4",
+    "sky130_fd_sc_ls__or3b_4",
     "Low Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_1 = logic_module(
-    "or4_1",
+    "sky130_fd_sc_ls__or4_1",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_2 = logic_module(
-    "or4_2",
+    "sky130_fd_sc_ls__or4_2",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_4 = logic_module(
-    "or4_4",
+    "sky130_fd_sc_ls__or4_4",
     "Low Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_1 = logic_module(
-    "or4b_1",
+    "sky130_fd_sc_ls__or4b_1",
     "Low Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_2 = logic_module(
-    "or4b_2",
+    "sky130_fd_sc_ls__or4b_2",
     "Low Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_4 = logic_module(
-    "or4b_4",
+    "sky130_fd_sc_ls__or4b_4",
     "Low Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_1 = logic_module(
-    "or4bb_1",
+    "sky130_fd_sc_ls__or4bb_1",
     "Low Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_2 = logic_module(
-    "or4bb_2",
+    "sky130_fd_sc_ls__or4bb_2",
     "Low Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_4 = logic_module(
-    "or4bb_4",
+    "sky130_fd_sc_ls__or4bb_4",
     "Low Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 sdfbbn_1 = logic_module(
-    "sdfbbn_1",
+    "sky130_fd_sc_ls__sdfbbn_1",
     "Low Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbn_2 = logic_module(
-    "sdfbbn_2",
+    "sky130_fd_sc_ls__sdfbbn_2",
     "Low Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbp_1 = logic_module(
-    "sdfbbp_1",
+    "sky130_fd_sc_ls__sdfbbp_1",
     "Low Speed",
     [
         "CLK",
@@ -1681,189 +1737,203 @@ sdfbbp_1 = logic_module(
     ],
 )
 sdfrbp_1 = logic_module(
-    "sdfrbp_1",
+    "sky130_fd_sc_ls__sdfrbp_1",
     "Low Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrbp_2 = logic_module(
-    "sdfrbp_2",
+    "sky130_fd_sc_ls__sdfrbp_2",
     "Low Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrtn_1 = logic_module(
-    "sdfrtn_1",
+    "sky130_fd_sc_ls__sdfrtn_1",
     "Low Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_1 = logic_module(
-    "sdfrtp_1",
+    "sky130_fd_sc_ls__sdfrtp_1",
     "Low Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_2 = logic_module(
-    "sdfrtp_2",
+    "sky130_fd_sc_ls__sdfrtp_2",
     "Low Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_4 = logic_module(
-    "sdfrtp_4",
+    "sky130_fd_sc_ls__sdfrtp_4",
     "Low Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfsbp_1 = logic_module(
-    "sdfsbp_1",
+    "sky130_fd_sc_ls__sdfsbp_1",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfsbp_2 = logic_module(
-    "sdfsbp_2",
+    "sky130_fd_sc_ls__sdfsbp_2",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfstp_1 = logic_module(
-    "sdfstp_1",
+    "sky130_fd_sc_ls__sdfstp_1",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_2 = logic_module(
-    "sdfstp_2",
+    "sky130_fd_sc_ls__sdfstp_2",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_4 = logic_module(
-    "sdfstp_4",
+    "sky130_fd_sc_ls__sdfstp_4",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxbp_1 = logic_module(
-    "sdfxbp_1",
+    "sky130_fd_sc_ls__sdfxbp_1",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxbp_2 = logic_module(
-    "sdfxbp_2",
+    "sky130_fd_sc_ls__sdfxbp_2",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxtp_1 = logic_module(
-    "sdfxtp_1",
+    "sky130_fd_sc_ls__sdfxtp_1",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_2 = logic_module(
-    "sdfxtp_2",
+    "sky130_fd_sc_ls__sdfxtp_2",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_4 = logic_module(
-    "sdfxtp_4",
+    "sky130_fd_sc_ls__sdfxtp_4",
     "Low Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdlclkp_1 = logic_module(
-    "sdlclkp_1",
+    "sky130_fd_sc_ls__sdlclkp_1",
     "Low Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_2 = logic_module(
-    "sdlclkp_2",
+    "sky130_fd_sc_ls__sdlclkp_2",
     "Low Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_4 = logic_module(
-    "sdlclkp_4",
+    "sky130_fd_sc_ls__sdlclkp_4",
     "Low Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sedfxbp_1 = logic_module(
-    "sedfxbp_1",
+    "sky130_fd_sc_ls__sedfxbp_1",
     "Low Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxbp_2 = logic_module(
-    "sedfxbp_2",
+    "sky130_fd_sc_ls__sedfxbp_2",
     "Low Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxtp_1 = logic_module(
-    "sedfxtp_1",
+    "sky130_fd_sc_ls__sedfxtp_1",
     "Low Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sedfxtp_2 = logic_module(
-    "sedfxtp_2",
+    "sky130_fd_sc_ls__sedfxtp_2",
     "Low Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sedfxtp_4 = logic_module(
-    "sedfxtp_4",
+    "sky130_fd_sc_ls__sedfxtp_4",
     "Low Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
-tap_1 = logic_module("tap_1", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-tap_2 = logic_module("tap_2", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"])
-tapmet1_2 = logic_module("tapmet1_2", "Low Speed", ["VGND", "VPB", "VPWR"])
-tapvgnd2_1 = logic_module("tapvgnd2_1", "Low Speed", ["VGND", "VPB", "VPWR"])
-tapvgnd_1 = logic_module("tapvgnd_1", "Low Speed", ["VGND", "VPB", "VPWR"])
-tapvgndnovpb_1 = logic_module("tapvgndnovpb_1", "Low Speed", ["VGND", "VPWR"])
-tapvpwrvgnd_1 = logic_module("tapvpwrvgnd_1", "Low Speed", ["VGND", "VPWR"])
+tap_1 = logic_module(
+    "sky130_fd_sc_ls__tap_1", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tap_2 = logic_module(
+    "sky130_fd_sc_ls__tap_2", "Low Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tapmet1_2 = logic_module(
+    "sky130_fd_sc_ls__tapmet1_2", "Low Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvgnd2_1 = logic_module(
+    "sky130_fd_sc_ls__tapvgnd2_1", "Low Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvgnd_1 = logic_module(
+    "sky130_fd_sc_ls__tapvgnd_1", "Low Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvgndnovpb_1 = logic_module(
+    "sky130_fd_sc_ls__tapvgndnovpb_1", "Low Speed", ["VGND", "VPWR"]
+)
+tapvpwrvgnd_1 = logic_module(
+    "sky130_fd_sc_ls__tapvpwrvgnd_1", "Low Speed", ["VGND", "VPWR"]
+)
 xnor2_1 = logic_module(
-    "xnor2_1",
+    "sky130_fd_sc_ls__xnor2_1",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_2 = logic_module(
-    "xnor2_2",
+    "sky130_fd_sc_ls__xnor2_2",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_4 = logic_module(
-    "xnor2_4",
+    "sky130_fd_sc_ls__xnor2_4",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor3_1 = logic_module(
-    "xnor3_1",
+    "sky130_fd_sc_ls__xnor3_1",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_2 = logic_module(
-    "xnor3_2",
+    "sky130_fd_sc_ls__xnor3_2",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_4 = logic_module(
-    "xnor3_4",
+    "sky130_fd_sc_ls__xnor3_4",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_1 = logic_module(
-    "xor2_1",
+    "sky130_fd_sc_ls__xor2_1",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_2 = logic_module(
-    "xor2_2",
+    "sky130_fd_sc_ls__xor2_2",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_4 = logic_module(
-    "xor2_4",
+    "sky130_fd_sc_ls__xor2_4",
     "Low Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_1 = logic_module(
-    "xor3_1",
+    "sky130_fd_sc_ls__xor3_1",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_2 = logic_module(
-    "xor3_2",
+    "sky130_fd_sc_ls__xor3_2",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_4 = logic_module(
-    "xor3_4",
+    "sky130_fd_sc_ls__xor3_4",
     "Low Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )

--- a/pdks/Sky130/sky130_hdl21/digital_cells/medium_speed.py
+++ b/pdks/Sky130/sky130_hdl21/digital_cells/medium_speed.py
@@ -1,1713 +1,1727 @@
 from ..pdk_data import logic_module
 
 a2bb2o_1 = logic_module(
-    "a2bb2o_1",
+    "sky130_fd_sc_ms__a2bb2o_1",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_2 = logic_module(
-    "a2bb2o_2",
+    "sky130_fd_sc_ms__a2bb2o_2",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2o_4 = logic_module(
-    "a2bb2o_4",
+    "sky130_fd_sc_ms__a2bb2o_4",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2bb2oi_1 = logic_module(
-    "a2bb2oi_1",
+    "sky130_fd_sc_ms__a2bb2oi_1",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_2 = logic_module(
-    "a2bb2oi_2",
+    "sky130_fd_sc_ms__a2bb2oi_2",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2bb2oi_4 = logic_module(
-    "a2bb2oi_4",
+    "sky130_fd_sc_ms__a2bb2oi_4",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21bo_1 = logic_module(
-    "a21bo_1",
+    "sky130_fd_sc_ms__a21bo_1",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_2 = logic_module(
-    "a21bo_2",
+    "sky130_fd_sc_ms__a21bo_2",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21bo_4 = logic_module(
-    "a21bo_4",
+    "sky130_fd_sc_ms__a21bo_4",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21boi_1 = logic_module(
-    "a21boi_1",
+    "sky130_fd_sc_ms__a21boi_1",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_2 = logic_module(
-    "a21boi_2",
+    "sky130_fd_sc_ms__a21boi_2",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21boi_4 = logic_module(
-    "a21boi_4",
+    "sky130_fd_sc_ms__a21boi_4",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21o_1 = logic_module(
-    "a21o_1",
+    "sky130_fd_sc_ms__a21o_1",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_2 = logic_module(
-    "a21o_2",
+    "sky130_fd_sc_ms__a21o_2",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21o_4 = logic_module(
-    "a21o_4",
+    "sky130_fd_sc_ms__a21o_4",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a21oi_1 = logic_module(
-    "a21oi_1",
+    "sky130_fd_sc_ms__a21oi_1",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_2 = logic_module(
-    "a21oi_2",
+    "sky130_fd_sc_ms__a21oi_2",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a21oi_4 = logic_module(
-    "a21oi_4",
+    "sky130_fd_sc_ms__a21oi_4",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22o_1 = logic_module(
-    "a22o_1",
+    "sky130_fd_sc_ms__a22o_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_2 = logic_module(
-    "a22o_2",
+    "sky130_fd_sc_ms__a22o_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22o_4 = logic_module(
-    "a22o_4",
+    "sky130_fd_sc_ms__a22o_4",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a22oi_1 = logic_module(
-    "a22oi_1",
+    "sky130_fd_sc_ms__a22oi_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_2 = logic_module(
-    "a22oi_2",
+    "sky130_fd_sc_ms__a22oi_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a22oi_4 = logic_module(
-    "a22oi_4",
+    "sky130_fd_sc_ms__a22oi_4",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31o_1 = logic_module(
-    "a31o_1",
+    "sky130_fd_sc_ms__a31o_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_2 = logic_module(
-    "a31o_2",
+    "sky130_fd_sc_ms__a31o_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31o_4 = logic_module(
-    "a31o_4",
+    "sky130_fd_sc_ms__a31o_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a31oi_1 = logic_module(
-    "a31oi_1",
+    "sky130_fd_sc_ms__a31oi_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_2 = logic_module(
-    "a31oi_2",
+    "sky130_fd_sc_ms__a31oi_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a31oi_4 = logic_module(
-    "a31oi_4",
+    "sky130_fd_sc_ms__a31oi_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32o_1 = logic_module(
-    "a32o_1",
+    "sky130_fd_sc_ms__a32o_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_2 = logic_module(
-    "a32o_2",
+    "sky130_fd_sc_ms__a32o_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32o_4 = logic_module(
-    "a32o_4",
+    "sky130_fd_sc_ms__a32o_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a32oi_1 = logic_module(
-    "a32oi_1",
+    "sky130_fd_sc_ms__a32oi_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_2 = logic_module(
-    "a32oi_2",
+    "sky130_fd_sc_ms__a32oi_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a32oi_4 = logic_module(
-    "a32oi_4",
+    "sky130_fd_sc_ms__a32oi_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41o_1 = logic_module(
-    "a41o_1",
+    "sky130_fd_sc_ms__a41o_1",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_2 = logic_module(
-    "a41o_2",
+    "sky130_fd_sc_ms__a41o_2",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41o_4 = logic_module(
-    "a41o_4",
+    "sky130_fd_sc_ms__a41o_4",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a41oi_1 = logic_module(
-    "a41oi_1",
+    "sky130_fd_sc_ms__a41oi_1",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_2 = logic_module(
-    "a41oi_2",
+    "sky130_fd_sc_ms__a41oi_2",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a41oi_4 = logic_module(
-    "a41oi_4",
+    "sky130_fd_sc_ms__a41oi_4",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211o_1 = logic_module(
-    "a211o_1",
+    "sky130_fd_sc_ms__a211o_1",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_2 = logic_module(
-    "a211o_2",
+    "sky130_fd_sc_ms__a211o_2",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211o_4 = logic_module(
-    "a211o_4",
+    "sky130_fd_sc_ms__a211o_4",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a211oi_1 = logic_module(
-    "a211oi_1",
+    "sky130_fd_sc_ms__a211oi_1",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_2 = logic_module(
-    "a211oi_2",
+    "sky130_fd_sc_ms__a211oi_2",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a211oi_4 = logic_module(
-    "a211oi_4",
+    "sky130_fd_sc_ms__a211oi_4",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221o_1 = logic_module(
-    "a221o_1",
+    "sky130_fd_sc_ms__a221o_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_2 = logic_module(
-    "a221o_2",
+    "sky130_fd_sc_ms__a221o_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221o_4 = logic_module(
-    "a221o_4",
+    "sky130_fd_sc_ms__a221o_4",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a221oi_1 = logic_module(
-    "a221oi_1",
+    "sky130_fd_sc_ms__a221oi_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_2 = logic_module(
-    "a221oi_2",
+    "sky130_fd_sc_ms__a221oi_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a221oi_4 = logic_module(
-    "a221oi_4",
+    "sky130_fd_sc_ms__a221oi_4",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a222o_1 = logic_module(
-    "a222o_1",
+    "sky130_fd_sc_ms__a222o_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a222o_2 = logic_module(
-    "a222o_2",
+    "sky130_fd_sc_ms__a222o_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a222oi_1 = logic_module(
-    "a222oi_1",
+    "sky130_fd_sc_ms__a222oi_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a222oi_2 = logic_module(
-    "a222oi_2",
+    "sky130_fd_sc_ms__a222oi_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "C2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311o_1 = logic_module(
-    "a311o_1",
+    "sky130_fd_sc_ms__a311o_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_2 = logic_module(
-    "a311o_2",
+    "sky130_fd_sc_ms__a311o_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311o_4 = logic_module(
-    "a311o_4",
+    "sky130_fd_sc_ms__a311o_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a311oi_1 = logic_module(
-    "a311oi_1",
+    "sky130_fd_sc_ms__a311oi_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_2 = logic_module(
-    "a311oi_2",
+    "sky130_fd_sc_ms__a311oi_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a311oi_4 = logic_module(
-    "a311oi_4",
+    "sky130_fd_sc_ms__a311oi_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111o_1 = logic_module(
-    "a2111o_1",
+    "sky130_fd_sc_ms__a2111o_1",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_2 = logic_module(
-    "a2111o_2",
+    "sky130_fd_sc_ms__a2111o_2",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111o_4 = logic_module(
-    "a2111o_4",
+    "sky130_fd_sc_ms__a2111o_4",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 a2111oi_1 = logic_module(
-    "a2111oi_1",
+    "sky130_fd_sc_ms__a2111oi_1",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_2 = logic_module(
-    "a2111oi_2",
+    "sky130_fd_sc_ms__a2111oi_2",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 a2111oi_4 = logic_module(
-    "a2111oi_4",
+    "sky130_fd_sc_ms__a2111oi_4",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 and2_1 = logic_module(
-    "and2_1",
+    "sky130_fd_sc_ms__and2_1",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_2 = logic_module(
-    "and2_2",
+    "sky130_fd_sc_ms__and2_2",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2_4 = logic_module(
-    "and2_4",
+    "sky130_fd_sc_ms__and2_4",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_1 = logic_module(
-    "and2b_1",
+    "sky130_fd_sc_ms__and2b_1",
     "Medium Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_2 = logic_module(
-    "and2b_2",
+    "sky130_fd_sc_ms__and2b_2",
     "Medium Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and2b_4 = logic_module(
-    "and2b_4",
+    "sky130_fd_sc_ms__and2b_4",
     "Medium Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_1 = logic_module(
-    "and3_1",
+    "sky130_fd_sc_ms__and3_1",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_2 = logic_module(
-    "and3_2",
+    "sky130_fd_sc_ms__and3_2",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3_4 = logic_module(
-    "and3_4",
+    "sky130_fd_sc_ms__and3_4",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_1 = logic_module(
-    "and3b_1",
+    "sky130_fd_sc_ms__and3b_1",
     "Medium Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_2 = logic_module(
-    "and3b_2",
+    "sky130_fd_sc_ms__and3b_2",
     "Medium Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and3b_4 = logic_module(
-    "and3b_4",
+    "sky130_fd_sc_ms__and3b_4",
     "Medium Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_1 = logic_module(
-    "and4_1",
+    "sky130_fd_sc_ms__and4_1",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_2 = logic_module(
-    "and4_2",
+    "sky130_fd_sc_ms__and4_2",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4_4 = logic_module(
-    "and4_4",
+    "sky130_fd_sc_ms__and4_4",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_1 = logic_module(
-    "and4b_1",
+    "sky130_fd_sc_ms__and4b_1",
     "Medium Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_2 = logic_module(
-    "and4b_2",
+    "sky130_fd_sc_ms__and4b_2",
     "Medium Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4b_4 = logic_module(
-    "and4b_4",
+    "sky130_fd_sc_ms__and4b_4",
     "Medium Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_1 = logic_module(
-    "and4bb_1",
+    "sky130_fd_sc_ms__and4bb_1",
     "Medium Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_2 = logic_module(
-    "and4bb_2",
+    "sky130_fd_sc_ms__and4bb_2",
     "Medium Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 and4bb_4 = logic_module(
-    "and4bb_4",
+    "sky130_fd_sc_ms__and4bb_4",
     "Medium Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_1 = logic_module(
-    "buf_1",
+    "sky130_fd_sc_ms__buf_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_2 = logic_module(
-    "buf_2",
+    "sky130_fd_sc_ms__buf_2",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_4 = logic_module(
-    "buf_4",
+    "sky130_fd_sc_ms__buf_4",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_8 = logic_module(
-    "buf_8",
+    "sky130_fd_sc_ms__buf_8",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 buf_16 = logic_module(
-    "buf_16",
+    "sky130_fd_sc_ms__buf_16",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_8 = logic_module(
-    "bufbuf_8",
+    "sky130_fd_sc_ms__bufbuf_8",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufbuf_16 = logic_module(
-    "bufbuf_16",
+    "sky130_fd_sc_ms__bufbuf_16",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 bufinv_8 = logic_module(
-    "bufinv_8",
+    "sky130_fd_sc_ms__bufinv_8",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 bufinv_16 = logic_module(
-    "bufinv_16",
+    "sky130_fd_sc_ms__bufinv_16",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkbuf_1 = logic_module(
-    "clkbuf_1",
+    "sky130_fd_sc_ms__clkbuf_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_2 = logic_module(
-    "clkbuf_2",
+    "sky130_fd_sc_ms__clkbuf_2",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_4 = logic_module(
-    "clkbuf_4",
+    "sky130_fd_sc_ms__clkbuf_4",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_8 = logic_module(
-    "clkbuf_8",
+    "sky130_fd_sc_ms__clkbuf_8",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkbuf_16 = logic_module(
-    "clkbuf_16",
+    "sky130_fd_sc_ms__clkbuf_16",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 clkdlyinv3sd1_1 = logic_module(
-    "clkdlyinv3sd1_1",
+    "sky130_fd_sc_ms__clkdlyinv3sd1_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv3sd2_1 = logic_module(
-    "clkdlyinv3sd2_1",
+    "sky130_fd_sc_ms__clkdlyinv3sd2_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv3sd3_1 = logic_module(
-    "clkdlyinv3sd3_1",
+    "sky130_fd_sc_ms__clkdlyinv3sd3_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd1_1 = logic_module(
-    "clkdlyinv5sd1_1",
+    "sky130_fd_sc_ms__clkdlyinv5sd1_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd2_1 = logic_module(
-    "clkdlyinv5sd2_1",
+    "sky130_fd_sc_ms__clkdlyinv5sd2_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkdlyinv5sd3_1 = logic_module(
-    "clkdlyinv5sd3_1",
+    "sky130_fd_sc_ms__clkdlyinv5sd3_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_1 = logic_module(
-    "clkinv_1",
+    "sky130_fd_sc_ms__clkinv_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_2 = logic_module(
-    "clkinv_2",
+    "sky130_fd_sc_ms__clkinv_2",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_4 = logic_module(
-    "clkinv_4",
+    "sky130_fd_sc_ms__clkinv_4",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_8 = logic_module(
-    "clkinv_8",
+    "sky130_fd_sc_ms__clkinv_8",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 clkinv_16 = logic_module(
-    "clkinv_16",
+    "sky130_fd_sc_ms__clkinv_16",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 conb_1 = logic_module(
-    "conb_1",
+    "sky130_fd_sc_ms__conb_1",
     "Medium Speed",
     ["VGND", "VNB", "VPB", "VPWR", "HI", "LO"],
 )
-decap_4 = logic_module("decap_4", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"])
-decap_8 = logic_module("decap_8", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"])
+decap_4 = logic_module(
+    "sky130_fd_sc_ms__decap_4", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+decap_8 = logic_module(
+    "sky130_fd_sc_ms__decap_8", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
 dfbbn_1 = logic_module(
-    "dfbbn_1",
+    "sky130_fd_sc_ms__dfbbn_1",
     "Medium Speed",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbn_2 = logic_module(
-    "dfbbn_2",
+    "sky130_fd_sc_ms__dfbbn_2",
     "Medium Speed",
     ["CLK_N", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfbbp_1 = logic_module(
-    "dfbbp_1",
+    "sky130_fd_sc_ms__dfbbp_1",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_1 = logic_module(
-    "dfrbp_1",
+    "sky130_fd_sc_ms__dfrbp_1",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrbp_2 = logic_module(
-    "dfrbp_2",
+    "sky130_fd_sc_ms__dfrbp_2",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfrtn_1 = logic_module(
-    "dfrtn_1",
+    "sky130_fd_sc_ms__dfrtn_1",
     "Medium Speed",
     ["CLK_N", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_1 = logic_module(
-    "dfrtp_1",
+    "sky130_fd_sc_ms__dfrtp_1",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_2 = logic_module(
-    "dfrtp_2",
+    "sky130_fd_sc_ms__dfrtp_2",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfrtp_4 = logic_module(
-    "dfrtp_4",
+    "sky130_fd_sc_ms__dfrtp_4",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfsbp_1 = logic_module(
-    "dfsbp_1",
+    "sky130_fd_sc_ms__dfsbp_1",
     "Medium Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfsbp_2 = logic_module(
-    "dfsbp_2",
+    "sky130_fd_sc_ms__dfsbp_2",
     "Medium Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfstp_1 = logic_module(
-    "dfstp_1",
+    "sky130_fd_sc_ms__dfstp_1",
     "Medium Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_2 = logic_module(
-    "dfstp_2",
+    "sky130_fd_sc_ms__dfstp_2",
     "Medium Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfstp_4 = logic_module(
-    "dfstp_4",
+    "sky130_fd_sc_ms__dfstp_4",
     "Medium Speed",
     ["CLK", "D", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxbp_1 = logic_module(
-    "dfxbp_1",
+    "sky130_fd_sc_ms__dfxbp_1",
     "Medium Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxbp_2 = logic_module(
-    "dfxbp_2",
+    "sky130_fd_sc_ms__dfxbp_2",
     "Medium Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dfxtp_1 = logic_module(
-    "dfxtp_1",
+    "sky130_fd_sc_ms__dfxtp_1",
     "Medium Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_2 = logic_module(
-    "dfxtp_2",
+    "sky130_fd_sc_ms__dfxtp_2",
     "Medium Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dfxtp_4 = logic_module(
-    "dfxtp_4",
+    "sky130_fd_sc_ms__dfxtp_4",
     "Medium Speed",
     ["CLK", "D", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 diode_2 = logic_module(
-    "diode_2",
+    "sky130_fd_sc_ms__diode_2",
     "Medium Speed",
     ["DIODE", "VGND", "VNB", "VPB", "VPWR"],
 )
 dlclkp_1 = logic_module(
-    "dlclkp_1",
+    "sky130_fd_sc_ms__dlclkp_1",
     "Medium Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_2 = logic_module(
-    "dlclkp_2",
+    "sky130_fd_sc_ms__dlclkp_2",
     "Medium Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlclkp_4 = logic_module(
-    "dlclkp_4",
+    "sky130_fd_sc_ms__dlclkp_4",
     "Medium Speed",
     ["CLK", "GATE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 dlrbn_1 = logic_module(
-    "dlrbn_1",
+    "sky130_fd_sc_ms__dlrbn_1",
     "Medium Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbn_2 = logic_module(
-    "dlrbn_2",
+    "sky130_fd_sc_ms__dlrbn_2",
     "Medium Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_1 = logic_module(
-    "dlrbp_1",
+    "sky130_fd_sc_ms__dlrbp_1",
     "Medium Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrbp_2 = logic_module(
-    "dlrbp_2",
+    "sky130_fd_sc_ms__dlrbp_2",
     "Medium Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlrtn_1 = logic_module(
-    "dlrtn_1",
+    "sky130_fd_sc_ms__dlrtn_1",
     "Medium Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_2 = logic_module(
-    "dlrtn_2",
+    "sky130_fd_sc_ms__dlrtn_2",
     "Medium Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtn_4 = logic_module(
-    "dlrtn_4",
+    "sky130_fd_sc_ms__dlrtn_4",
     "Medium Speed",
     ["D", "GATE_N", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_1 = logic_module(
-    "dlrtp_1",
+    "sky130_fd_sc_ms__dlrtp_1",
     "Medium Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_2 = logic_module(
-    "dlrtp_2",
+    "sky130_fd_sc_ms__dlrtp_2",
     "Medium Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlrtp_4 = logic_module(
-    "dlrtp_4",
+    "sky130_fd_sc_ms__dlrtp_4",
     "Medium Speed",
     ["D", "GATE", "RESET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxbn_1 = logic_module(
-    "dlxbn_1",
+    "sky130_fd_sc_ms__dlxbn_1",
     "Medium Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbn_2 = logic_module(
-    "dlxbn_2",
+    "sky130_fd_sc_ms__dlxbn_2",
     "Medium Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxbp_1 = logic_module(
-    "dlxbp_1",
+    "sky130_fd_sc_ms__dlxbp_1",
     "Medium Speed",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 dlxtn_1 = logic_module(
-    "dlxtn_1",
+    "sky130_fd_sc_ms__dlxtn_1",
     "Medium Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_2 = logic_module(
-    "dlxtn_2",
+    "sky130_fd_sc_ms__dlxtn_2",
     "Medium Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtn_4 = logic_module(
-    "dlxtn_4",
+    "sky130_fd_sc_ms__dlxtn_4",
     "Medium Speed",
     ["D", "GATE_N", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlxtp_1 = logic_module(
-    "dlxtp_1",
+    "sky130_fd_sc_ms__dlxtp_1",
     "Medium Speed",
     ["D", "GATE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 dlygate4sd1_1 = logic_module(
-    "dlygate4sd1_1",
+    "sky130_fd_sc_ms__dlygate4sd1_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd2_1 = logic_module(
-    "dlygate4sd2_1",
+    "sky130_fd_sc_ms__dlygate4sd2_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlygate4sd3_1 = logic_module(
-    "dlygate4sd3_1",
+    "sky130_fd_sc_ms__dlygate4sd3_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s2s_1 = logic_module(
-    "dlymetal6s2s_1",
+    "sky130_fd_sc_ms__dlymetal6s2s_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s4s_1 = logic_module(
-    "dlymetal6s4s_1",
+    "sky130_fd_sc_ms__dlymetal6s4s_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 dlymetal6s6s_1 = logic_module(
-    "dlymetal6s6s_1",
+    "sky130_fd_sc_ms__dlymetal6s6s_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 ebufn_1 = logic_module(
-    "ebufn_1",
+    "sky130_fd_sc_ms__ebufn_1",
     "Medium Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_2 = logic_module(
-    "ebufn_2",
+    "sky130_fd_sc_ms__ebufn_2",
     "Medium Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_4 = logic_module(
-    "ebufn_4",
+    "sky130_fd_sc_ms__ebufn_4",
     "Medium Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 ebufn_8 = logic_module(
-    "ebufn_8",
+    "sky130_fd_sc_ms__ebufn_8",
     "Medium Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 edfxbp_1 = logic_module(
-    "edfxbp_1",
+    "sky130_fd_sc_ms__edfxbp_1",
     "Medium Speed",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 edfxtp_1 = logic_module(
-    "edfxtp_1",
+    "sky130_fd_sc_ms__edfxtp_1",
     "Medium Speed",
     ["CLK", "D", "DE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 einvn_1 = logic_module(
-    "einvn_1",
+    "sky130_fd_sc_ms__einvn_1",
     "Medium Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_2 = logic_module(
-    "einvn_2",
+    "sky130_fd_sc_ms__einvn_2",
     "Medium Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_4 = logic_module(
-    "einvn_4",
+    "sky130_fd_sc_ms__einvn_4",
     "Medium Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvn_8 = logic_module(
-    "einvn_8",
+    "sky130_fd_sc_ms__einvn_8",
     "Medium Speed",
     ["A", "TE_B", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_1 = logic_module(
-    "einvp_1",
+    "sky130_fd_sc_ms__einvp_1",
     "Medium Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_2 = logic_module(
-    "einvp_2",
+    "sky130_fd_sc_ms__einvp_2",
     "Medium Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_4 = logic_module(
-    "einvp_4",
+    "sky130_fd_sc_ms__einvp_4",
     "Medium Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 einvp_8 = logic_module(
-    "einvp_8",
+    "sky130_fd_sc_ms__einvp_8",
     "Medium Speed",
     ["A", "TE", "VGND", "VNB", "VPB", "VPWR", "Z"],
 )
 fa_1 = logic_module(
-    "fa_1",
+    "sky130_fd_sc_ms__fa_1",
     "Medium Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_2 = logic_module(
-    "fa_2",
+    "sky130_fd_sc_ms__fa_2",
     "Medium Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fa_4 = logic_module(
-    "fa_4",
+    "sky130_fd_sc_ms__fa_4",
     "Medium Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_1 = logic_module(
-    "fah_1",
+    "sky130_fd_sc_ms__fah_1",
     "Medium Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_2 = logic_module(
-    "fah_2",
+    "sky130_fd_sc_ms__fah_2",
     "Medium Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fah_4 = logic_module(
-    "fah_4",
+    "sky130_fd_sc_ms__fah_4",
     "Medium Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcin_1 = logic_module(
-    "fahcin_1",
+    "sky130_fd_sc_ms__fahcin_1",
     "Medium Speed",
     ["A", "B", "CIN", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 fahcon_1 = logic_module(
-    "fahcon_1",
+    "sky130_fd_sc_ms__fahcon_1",
     "Medium Speed",
     ["A", "B", "CI", "VGND", "VNB", "VPB", "VPWR", "COUT_N", "SUM"],
 )
-fill_1 = logic_module("fill_1", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_2 = logic_module("fill_2", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_4 = logic_module("fill_4", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"])
-fill_8 = logic_module("fill_8", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"])
+fill_1 = logic_module(
+    "sky130_fd_sc_ms__fill_1", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_2 = logic_module(
+    "sky130_fd_sc_ms__fill_2", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_4 = logic_module(
+    "sky130_fd_sc_ms__fill_4", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+fill_8 = logic_module(
+    "sky130_fd_sc_ms__fill_8", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
 fill_diode_2 = logic_module(
-    "fill_diode_2", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+    "sky130_fd_sc_ms__fill_diode_2", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
 )
 fill_diode_4 = logic_module(
-    "fill_diode_4", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+    "sky130_fd_sc_ms__fill_diode_4", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
 )
 fill_diode_8 = logic_module(
-    "fill_diode_8", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+    "sky130_fd_sc_ms__fill_diode_8", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
 )
 ha_1 = logic_module(
-    "ha_1",
+    "sky130_fd_sc_ms__ha_1",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_2 = logic_module(
-    "ha_2",
+    "sky130_fd_sc_ms__ha_2",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 ha_4 = logic_module(
-    "ha_4",
+    "sky130_fd_sc_ms__ha_4",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "COUT", "SUM"],
 )
 inv_1 = logic_module(
-    "inv_1",
+    "sky130_fd_sc_ms__inv_1",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_2 = logic_module(
-    "inv_2",
+    "sky130_fd_sc_ms__inv_2",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_4 = logic_module(
-    "inv_4",
+    "sky130_fd_sc_ms__inv_4",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_8 = logic_module(
-    "inv_8",
+    "sky130_fd_sc_ms__inv_8",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 inv_16 = logic_module(
-    "inv_16",
+    "sky130_fd_sc_ms__inv_16",
     "Medium Speed",
     ["A", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
-latchupcell = logic_module("latchupcell", "Medium Speed", ["VGND", "VPWR"])
+latchupcell = logic_module(
+    "sky130_fd_sc_ms__latchupcell", "Medium Speed", ["VGND", "VPWR"]
+)
 maj3_1 = logic_module(
-    "maj3_1",
+    "sky130_fd_sc_ms__maj3_1",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_2 = logic_module(
-    "maj3_2",
+    "sky130_fd_sc_ms__maj3_2",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 maj3_4 = logic_module(
-    "maj3_4",
+    "sky130_fd_sc_ms__maj3_4",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_1 = logic_module(
-    "mux2_1",
+    "sky130_fd_sc_ms__mux2_1",
     "Medium Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_2 = logic_module(
-    "mux2_2",
+    "sky130_fd_sc_ms__mux2_2",
     "Medium Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2_4 = logic_module(
-    "mux2_4",
+    "sky130_fd_sc_ms__mux2_4",
     "Medium Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux2i_1 = logic_module(
-    "mux2i_1",
+    "sky130_fd_sc_ms__mux2i_1",
     "Medium Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_2 = logic_module(
-    "mux2i_2",
+    "sky130_fd_sc_ms__mux2i_2",
     "Medium Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux2i_4 = logic_module(
-    "mux2i_4",
+    "sky130_fd_sc_ms__mux2i_4",
     "Medium Speed",
     ["A0", "A1", "S", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 mux4_1 = logic_module(
-    "mux4_1",
+    "sky130_fd_sc_ms__mux4_1",
     "Medium Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_2 = logic_module(
-    "mux4_2",
+    "sky130_fd_sc_ms__mux4_2",
     "Medium Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 mux4_4 = logic_module(
-    "mux4_4",
+    "sky130_fd_sc_ms__mux4_4",
     "Medium Speed",
     ["A0", "A1", "A2", "A3", "S0", "S1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 nand2_1 = logic_module(
-    "nand2_1",
+    "sky130_fd_sc_ms__nand2_1",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_2 = logic_module(
-    "nand2_2",
+    "sky130_fd_sc_ms__nand2_2",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_4 = logic_module(
-    "nand2_4",
+    "sky130_fd_sc_ms__nand2_4",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2_8 = logic_module(
-    "nand2_8",
+    "sky130_fd_sc_ms__nand2_8",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_1 = logic_module(
-    "nand2b_1",
+    "sky130_fd_sc_ms__nand2b_1",
     "Medium Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_2 = logic_module(
-    "nand2b_2",
+    "sky130_fd_sc_ms__nand2b_2",
     "Medium Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand2b_4 = logic_module(
-    "nand2b_4",
+    "sky130_fd_sc_ms__nand2b_4",
     "Medium Speed",
     ["A_N", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_1 = logic_module(
-    "nand3_1",
+    "sky130_fd_sc_ms__nand3_1",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_2 = logic_module(
-    "nand3_2",
+    "sky130_fd_sc_ms__nand3_2",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3_4 = logic_module(
-    "nand3_4",
+    "sky130_fd_sc_ms__nand3_4",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_1 = logic_module(
-    "nand3b_1",
+    "sky130_fd_sc_ms__nand3b_1",
     "Medium Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_2 = logic_module(
-    "nand3b_2",
+    "sky130_fd_sc_ms__nand3b_2",
     "Medium Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand3b_4 = logic_module(
-    "nand3b_4",
+    "sky130_fd_sc_ms__nand3b_4",
     "Medium Speed",
     ["A_N", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_1 = logic_module(
-    "nand4_1",
+    "sky130_fd_sc_ms__nand4_1",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_2 = logic_module(
-    "nand4_2",
+    "sky130_fd_sc_ms__nand4_2",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4_4 = logic_module(
-    "nand4_4",
+    "sky130_fd_sc_ms__nand4_4",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_1 = logic_module(
-    "nand4b_1",
+    "sky130_fd_sc_ms__nand4b_1",
     "Medium Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_2 = logic_module(
-    "nand4b_2",
+    "sky130_fd_sc_ms__nand4b_2",
     "Medium Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4b_4 = logic_module(
-    "nand4b_4",
+    "sky130_fd_sc_ms__nand4b_4",
     "Medium Speed",
     ["A_N", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_1 = logic_module(
-    "nand4bb_1",
+    "sky130_fd_sc_ms__nand4bb_1",
     "Medium Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_2 = logic_module(
-    "nand4bb_2",
+    "sky130_fd_sc_ms__nand4bb_2",
     "Medium Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nand4bb_4 = logic_module(
-    "nand4bb_4",
+    "sky130_fd_sc_ms__nand4bb_4",
     "Medium Speed",
     ["A_N", "B_N", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_1 = logic_module(
-    "nor2_1",
+    "sky130_fd_sc_ms__nor2_1",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_2 = logic_module(
-    "nor2_2",
+    "sky130_fd_sc_ms__nor2_2",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_4 = logic_module(
-    "nor2_4",
+    "sky130_fd_sc_ms__nor2_4",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2_8 = logic_module(
-    "nor2_8",
+    "sky130_fd_sc_ms__nor2_8",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_1 = logic_module(
-    "nor2b_1",
+    "sky130_fd_sc_ms__nor2b_1",
     "Medium Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_2 = logic_module(
-    "nor2b_2",
+    "sky130_fd_sc_ms__nor2b_2",
     "Medium Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor2b_4 = logic_module(
-    "nor2b_4",
+    "sky130_fd_sc_ms__nor2b_4",
     "Medium Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_1 = logic_module(
-    "nor3_1",
+    "sky130_fd_sc_ms__nor3_1",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_2 = logic_module(
-    "nor3_2",
+    "sky130_fd_sc_ms__nor3_2",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3_4 = logic_module(
-    "nor3_4",
+    "sky130_fd_sc_ms__nor3_4",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_1 = logic_module(
-    "nor3b_1",
+    "sky130_fd_sc_ms__nor3b_1",
     "Medium Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_2 = logic_module(
-    "nor3b_2",
+    "sky130_fd_sc_ms__nor3b_2",
     "Medium Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor3b_4 = logic_module(
-    "nor3b_4",
+    "sky130_fd_sc_ms__nor3b_4",
     "Medium Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_1 = logic_module(
-    "nor4_1",
+    "sky130_fd_sc_ms__nor4_1",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_2 = logic_module(
-    "nor4_2",
+    "sky130_fd_sc_ms__nor4_2",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4_4 = logic_module(
-    "nor4_4",
+    "sky130_fd_sc_ms__nor4_4",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_1 = logic_module(
-    "nor4b_1",
+    "sky130_fd_sc_ms__nor4b_1",
     "Medium Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_2 = logic_module(
-    "nor4b_2",
+    "sky130_fd_sc_ms__nor4b_2",
     "Medium Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4b_4 = logic_module(
-    "nor4b_4",
+    "sky130_fd_sc_ms__nor4b_4",
     "Medium Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_1 = logic_module(
-    "nor4bb_1",
+    "sky130_fd_sc_ms__nor4bb_1",
     "Medium Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_2 = logic_module(
-    "nor4bb_2",
+    "sky130_fd_sc_ms__nor4bb_2",
     "Medium Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 nor4bb_4 = logic_module(
-    "nor4bb_4",
+    "sky130_fd_sc_ms__nor4bb_4",
     "Medium Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2a_1 = logic_module(
-    "o2bb2a_1",
+    "sky130_fd_sc_ms__o2bb2a_1",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_2 = logic_module(
-    "o2bb2a_2",
+    "sky130_fd_sc_ms__o2bb2a_2",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2a_4 = logic_module(
-    "o2bb2a_4",
+    "sky130_fd_sc_ms__o2bb2a_4",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2bb2ai_1 = logic_module(
-    "o2bb2ai_1",
+    "sky130_fd_sc_ms__o2bb2ai_1",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_2 = logic_module(
-    "o2bb2ai_2",
+    "sky130_fd_sc_ms__o2bb2ai_2",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2bb2ai_4 = logic_module(
-    "o2bb2ai_4",
+    "sky130_fd_sc_ms__o2bb2ai_4",
     "Medium Speed",
     ["A1_N", "A2_N", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21a_1 = logic_module(
-    "o21a_1",
+    "sky130_fd_sc_ms__o21a_1",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_2 = logic_module(
-    "o21a_2",
+    "sky130_fd_sc_ms__o21a_2",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21a_4 = logic_module(
-    "o21a_4",
+    "sky130_fd_sc_ms__o21a_4",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ai_1 = logic_module(
-    "o21ai_1",
+    "sky130_fd_sc_ms__o21ai_1",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_2 = logic_module(
-    "o21ai_2",
+    "sky130_fd_sc_ms__o21ai_2",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ai_4 = logic_module(
-    "o21ai_4",
+    "sky130_fd_sc_ms__o21ai_4",
     "Medium Speed",
     ["A1", "A2", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21ba_1 = logic_module(
-    "o21ba_1",
+    "sky130_fd_sc_ms__o21ba_1",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_2 = logic_module(
-    "o21ba_2",
+    "sky130_fd_sc_ms__o21ba_2",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21ba_4 = logic_module(
-    "o21ba_4",
+    "sky130_fd_sc_ms__o21ba_4",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o21bai_1 = logic_module(
-    "o21bai_1",
+    "sky130_fd_sc_ms__o21bai_1",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_2 = logic_module(
-    "o21bai_2",
+    "sky130_fd_sc_ms__o21bai_2",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o21bai_4 = logic_module(
-    "o21bai_4",
+    "sky130_fd_sc_ms__o21bai_4",
     "Medium Speed",
     ["A1", "A2", "B1_N", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22a_1 = logic_module(
-    "o22a_1",
+    "sky130_fd_sc_ms__o22a_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_2 = logic_module(
-    "o22a_2",
+    "sky130_fd_sc_ms__o22a_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22a_4 = logic_module(
-    "o22a_4",
+    "sky130_fd_sc_ms__o22a_4",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o22ai_1 = logic_module(
-    "o22ai_1",
+    "sky130_fd_sc_ms__o22ai_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_2 = logic_module(
-    "o22ai_2",
+    "sky130_fd_sc_ms__o22ai_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o22ai_4 = logic_module(
-    "o22ai_4",
+    "sky130_fd_sc_ms__o22ai_4",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31a_1 = logic_module(
-    "o31a_1",
+    "sky130_fd_sc_ms__o31a_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_2 = logic_module(
-    "o31a_2",
+    "sky130_fd_sc_ms__o31a_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31a_4 = logic_module(
-    "o31a_4",
+    "sky130_fd_sc_ms__o31a_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o31ai_1 = logic_module(
-    "o31ai_1",
+    "sky130_fd_sc_ms__o31ai_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_2 = logic_module(
-    "o31ai_2",
+    "sky130_fd_sc_ms__o31ai_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o31ai_4 = logic_module(
-    "o31ai_4",
+    "sky130_fd_sc_ms__o31ai_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32a_1 = logic_module(
-    "o32a_1",
+    "sky130_fd_sc_ms__o32a_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_2 = logic_module(
-    "o32a_2",
+    "sky130_fd_sc_ms__o32a_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32a_4 = logic_module(
-    "o32a_4",
+    "sky130_fd_sc_ms__o32a_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o32ai_1 = logic_module(
-    "o32ai_1",
+    "sky130_fd_sc_ms__o32ai_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_2 = logic_module(
-    "o32ai_2",
+    "sky130_fd_sc_ms__o32ai_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o32ai_4 = logic_module(
-    "o32ai_4",
+    "sky130_fd_sc_ms__o32ai_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "B2", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41a_1 = logic_module(
-    "o41a_1",
+    "sky130_fd_sc_ms__o41a_1",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_2 = logic_module(
-    "o41a_2",
+    "sky130_fd_sc_ms__o41a_2",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41a_4 = logic_module(
-    "o41a_4",
+    "sky130_fd_sc_ms__o41a_4",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o41ai_1 = logic_module(
-    "o41ai_1",
+    "sky130_fd_sc_ms__o41ai_1",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_2 = logic_module(
-    "o41ai_2",
+    "sky130_fd_sc_ms__o41ai_2",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o41ai_4 = logic_module(
-    "o41ai_4",
+    "sky130_fd_sc_ms__o41ai_4",
     "Medium Speed",
     ["A1", "A2", "A3", "A4", "B1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211a_1 = logic_module(
-    "o211a_1",
+    "sky130_fd_sc_ms__o211a_1",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_2 = logic_module(
-    "o211a_2",
+    "sky130_fd_sc_ms__o211a_2",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211a_4 = logic_module(
-    "o211a_4",
+    "sky130_fd_sc_ms__o211a_4",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o211ai_1 = logic_module(
-    "o211ai_1",
+    "sky130_fd_sc_ms__o211ai_1",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_2 = logic_module(
-    "o211ai_2",
+    "sky130_fd_sc_ms__o211ai_2",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o211ai_4 = logic_module(
-    "o211ai_4",
+    "sky130_fd_sc_ms__o211ai_4",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221a_1 = logic_module(
-    "o221a_1",
+    "sky130_fd_sc_ms__o221a_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_2 = logic_module(
-    "o221a_2",
+    "sky130_fd_sc_ms__o221a_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221a_4 = logic_module(
-    "o221a_4",
+    "sky130_fd_sc_ms__o221a_4",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o221ai_1 = logic_module(
-    "o221ai_1",
+    "sky130_fd_sc_ms__o221ai_1",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_2 = logic_module(
-    "o221ai_2",
+    "sky130_fd_sc_ms__o221ai_2",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o221ai_4 = logic_module(
-    "o221ai_4",
+    "sky130_fd_sc_ms__o221ai_4",
     "Medium Speed",
     ["A1", "A2", "B1", "B2", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311a_1 = logic_module(
-    "o311a_1",
+    "sky130_fd_sc_ms__o311a_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_2 = logic_module(
-    "o311a_2",
+    "sky130_fd_sc_ms__o311a_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311a_4 = logic_module(
-    "o311a_4",
+    "sky130_fd_sc_ms__o311a_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o311ai_1 = logic_module(
-    "o311ai_1",
+    "sky130_fd_sc_ms__o311ai_1",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_2 = logic_module(
-    "o311ai_2",
+    "sky130_fd_sc_ms__o311ai_2",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o311ai_4 = logic_module(
-    "o311ai_4",
+    "sky130_fd_sc_ms__o311ai_4",
     "Medium Speed",
     ["A1", "A2", "A3", "B1", "C1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111a_1 = logic_module(
-    "o2111a_1",
+    "sky130_fd_sc_ms__o2111a_1",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_2 = logic_module(
-    "o2111a_2",
+    "sky130_fd_sc_ms__o2111a_2",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111a_4 = logic_module(
-    "o2111a_4",
+    "sky130_fd_sc_ms__o2111a_4",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 o2111ai_1 = logic_module(
-    "o2111ai_1",
+    "sky130_fd_sc_ms__o2111ai_1",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_2 = logic_module(
-    "o2111ai_2",
+    "sky130_fd_sc_ms__o2111ai_2",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 o2111ai_4 = logic_module(
-    "o2111ai_4",
+    "sky130_fd_sc_ms__o2111ai_4",
     "Medium Speed",
     ["A1", "A2", "B1", "C1", "D1", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 or2_1 = logic_module(
-    "or2_1",
+    "sky130_fd_sc_ms__or2_1",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_2 = logic_module(
-    "or2_2",
+    "sky130_fd_sc_ms__or2_2",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2_4 = logic_module(
-    "or2_4",
+    "sky130_fd_sc_ms__or2_4",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_1 = logic_module(
-    "or2b_1",
+    "sky130_fd_sc_ms__or2b_1",
     "Medium Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_2 = logic_module(
-    "or2b_2",
+    "sky130_fd_sc_ms__or2b_2",
     "Medium Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or2b_4 = logic_module(
-    "or2b_4",
+    "sky130_fd_sc_ms__or2b_4",
     "Medium Speed",
     ["A", "B_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_1 = logic_module(
-    "or3_1",
+    "sky130_fd_sc_ms__or3_1",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_2 = logic_module(
-    "or3_2",
+    "sky130_fd_sc_ms__or3_2",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3_4 = logic_module(
-    "or3_4",
+    "sky130_fd_sc_ms__or3_4",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_1 = logic_module(
-    "or3b_1",
+    "sky130_fd_sc_ms__or3b_1",
     "Medium Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_2 = logic_module(
-    "or3b_2",
+    "sky130_fd_sc_ms__or3b_2",
     "Medium Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or3b_4 = logic_module(
-    "or3b_4",
+    "sky130_fd_sc_ms__or3b_4",
     "Medium Speed",
     ["A", "B", "C_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_1 = logic_module(
-    "or4_1",
+    "sky130_fd_sc_ms__or4_1",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_2 = logic_module(
-    "or4_2",
+    "sky130_fd_sc_ms__or4_2",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4_4 = logic_module(
-    "or4_4",
+    "sky130_fd_sc_ms__or4_4",
     "Medium Speed",
     ["A", "B", "C", "D", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_1 = logic_module(
-    "or4b_1",
+    "sky130_fd_sc_ms__or4b_1",
     "Medium Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_2 = logic_module(
-    "or4b_2",
+    "sky130_fd_sc_ms__or4b_2",
     "Medium Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4b_4 = logic_module(
-    "or4b_4",
+    "sky130_fd_sc_ms__or4b_4",
     "Medium Speed",
     ["A", "B", "C", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_1 = logic_module(
-    "or4bb_1",
+    "sky130_fd_sc_ms__or4bb_1",
     "Medium Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_2 = logic_module(
-    "or4bb_2",
+    "sky130_fd_sc_ms__or4bb_2",
     "Medium Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 or4bb_4 = logic_module(
-    "or4bb_4",
+    "sky130_fd_sc_ms__or4bb_4",
     "Medium Speed",
     ["A", "B", "C_N", "D_N", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 sdfbbn_1 = logic_module(
-    "sdfbbn_1",
+    "sky130_fd_sc_ms__sdfbbn_1",
     "Medium Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbn_2 = logic_module(
-    "sdfbbn_2",
+    "sky130_fd_sc_ms__sdfbbn_2",
     "Medium Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR"],
 )
 sdfbbp_1 = logic_module(
-    "sdfbbp_1",
+    "sky130_fd_sc_ms__sdfbbp_1",
     "Medium Speed",
     [
         "CLK",
@@ -1724,188 +1738,200 @@ sdfbbp_1 = logic_module(
     ],
 )
 sdfrbp_1 = logic_module(
-    "sdfrbp_1",
+    "sky130_fd_sc_ms__sdfrbp_1",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrbp_2 = logic_module(
-    "sdfrbp_2",
+    "sky130_fd_sc_ms__sdfrbp_2",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfrtn_1 = logic_module(
-    "sdfrtn_1",
+    "sky130_fd_sc_ms__sdfrtn_1",
     "Medium Speed",
     ["CLK_N", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_1 = logic_module(
-    "sdfrtp_1",
+    "sky130_fd_sc_ms__sdfrtp_1",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_2 = logic_module(
-    "sdfrtp_2",
+    "sky130_fd_sc_ms__sdfrtp_2",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfrtp_4 = logic_module(
-    "sdfrtp_4",
+    "sky130_fd_sc_ms__sdfrtp_4",
     "Medium Speed",
     ["CLK", "D", "RESET_B", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfsbp_1 = logic_module(
-    "sdfsbp_1",
+    "sky130_fd_sc_ms__sdfsbp_1",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfsbp_2 = logic_module(
-    "sdfsbp_2",
+    "sky130_fd_sc_ms__sdfsbp_2",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfstp_1 = logic_module(
-    "sdfstp_1",
+    "sky130_fd_sc_ms__sdfstp_1",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_2 = logic_module(
-    "sdfstp_2",
+    "sky130_fd_sc_ms__sdfstp_2",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfstp_4 = logic_module(
-    "sdfstp_4",
+    "sky130_fd_sc_ms__sdfstp_4",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "SET_B", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxbp_1 = logic_module(
-    "sdfxbp_1",
+    "sky130_fd_sc_ms__sdfxbp_1",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxbp_2 = logic_module(
-    "sdfxbp_2",
+    "sky130_fd_sc_ms__sdfxbp_2",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sdfxtp_1 = logic_module(
-    "sdfxtp_1",
+    "sky130_fd_sc_ms__sdfxtp_1",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_2 = logic_module(
-    "sdfxtp_2",
+    "sky130_fd_sc_ms__sdfxtp_2",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdfxtp_4 = logic_module(
-    "sdfxtp_4",
+    "sky130_fd_sc_ms__sdfxtp_4",
     "Medium Speed",
     ["CLK", "D", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sdlclkp_1 = logic_module(
-    "sdlclkp_1",
+    "sky130_fd_sc_ms__sdlclkp_1",
     "Medium Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_2 = logic_module(
-    "sdlclkp_2",
+    "sky130_fd_sc_ms__sdlclkp_2",
     "Medium Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sdlclkp_4 = logic_module(
-    "sdlclkp_4",
+    "sky130_fd_sc_ms__sdlclkp_4",
     "Medium Speed",
     ["CLK", "GATE", "SCE", "VGND", "VNB", "VPB", "VPWR", "GCLK"],
 )
 sedfxbp_1 = logic_module(
-    "sedfxbp_1",
+    "sky130_fd_sc_ms__sedfxbp_1",
     "Medium Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxbp_2 = logic_module(
-    "sedfxbp_2",
+    "sky130_fd_sc_ms__sedfxbp_2",
     "Medium Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q", "Q_N"],
 )
 sedfxtp_1 = logic_module(
-    "sedfxtp_1",
+    "sky130_fd_sc_ms__sedfxtp_1",
     "Medium Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sedfxtp_2 = logic_module(
-    "sedfxtp_2",
+    "sky130_fd_sc_ms__sedfxtp_2",
     "Medium Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
 sedfxtp_4 = logic_module(
-    "sedfxtp_4",
+    "sky130_fd_sc_ms__sedfxtp_4",
     "Medium Speed",
     ["CLK", "D", "DE", "SCD", "SCE", "VGND", "VNB", "VPB", "VPWR", "Q"],
 )
-tap_1 = logic_module("tap_1", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"])
-tap_2 = logic_module("tap_2", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"])
-tapmet1_2 = logic_module("tapmet1_2", "Medium Speed", ["VGND", "VPB", "VPWR"])
-tapvgnd2_1 = logic_module("tapvgnd2_1", "Medium Speed", ["VGND", "VPB", "VPWR"])
-tapvgnd_1 = logic_module("tapvgnd_1", "Medium Speed", ["VGND", "VPB", "VPWR"])
-tapvpwrvgnd_1 = logic_module("tapvpwrvgnd_1", "Medium Speed", ["VGND", "VPWR"])
+tap_1 = logic_module(
+    "sky130_fd_sc_ms__tap_1", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tap_2 = logic_module(
+    "sky130_fd_sc_ms__tap_2", "Medium Speed", ["VGND", "VNB", "VPB", "VPWR"]
+)
+tapmet1_2 = logic_module(
+    "sky130_fd_sc_ms__tapmet1_2", "Medium Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvgnd2_1 = logic_module(
+    "sky130_fd_sc_ms__tapvgnd2_1", "Medium Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvgnd_1 = logic_module(
+    "sky130_fd_sc_ms__tapvgnd_1", "Medium Speed", ["VGND", "VPB", "VPWR"]
+)
+tapvpwrvgnd_1 = logic_module(
+    "sky130_fd_sc_ms__tapvpwrvgnd_1", "Medium Speed", ["VGND", "VPWR"]
+)
 xnor2_1 = logic_module(
-    "xnor2_1",
+    "sky130_fd_sc_ms__xnor2_1",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_2 = logic_module(
-    "xnor2_2",
+    "sky130_fd_sc_ms__xnor2_2",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor2_4 = logic_module(
-    "xnor2_4",
+    "sky130_fd_sc_ms__xnor2_4",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "Y"],
 )
 xnor3_1 = logic_module(
-    "xnor3_1",
+    "sky130_fd_sc_ms__xnor3_1",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_2 = logic_module(
-    "xnor3_2",
+    "sky130_fd_sc_ms__xnor3_2",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xnor3_4 = logic_module(
-    "xnor3_4",
+    "sky130_fd_sc_ms__xnor3_4",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_1 = logic_module(
-    "xor2_1",
+    "sky130_fd_sc_ms__xor2_1",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_2 = logic_module(
-    "xor2_2",
+    "sky130_fd_sc_ms__xor2_2",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor2_4 = logic_module(
-    "xor2_4",
+    "sky130_fd_sc_ms__xor2_4",
     "Medium Speed",
     ["A", "B", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_1 = logic_module(
-    "xor3_1",
+    "sky130_fd_sc_ms__xor3_1",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_2 = logic_module(
-    "xor3_2",
+    "sky130_fd_sc_ms__xor3_2",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )
 xor3_4 = logic_module(
-    "xor3_4",
+    "sky130_fd_sc_ms__xor3_4",
     "Medium Speed",
     ["A", "B", "C", "VGND", "VNB", "VPB", "VPWR", "X"],
 )


### PR DESCRIPTION
Noticed that digital cell naming went awry using "clever" mass-editing. Here are the corrected digital cell names so that netlisting works correctly - would also like to request that `sky130-hdl21` and `gf180-hdl21` get bumped up to `v4.0.1` with this patch.