### PR TITLE
extended prefixed arithmetic to work with other types

### DIFF
--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -69,6 +69,9 @@ class Prefix(Enum):
             # Prefix times Prefix, eg. `p * M == µ`
             targ = self.value + other.value
             return e(targ)
+        elif isinstance(other, (str, int, float, Decimal, Prefixed)):
+            # Prefix times number, eg. `p * 5 == 5 * p == 5 * Prefix.UNIT`
+            return self.__rmul__(other)
 
         return NotImplemented
 
@@ -201,9 +204,12 @@ class Prefixed(BaseModel):
     def __float__(self) -> float:
         """Convert to float"""
         return float(self.number) * 10**self.prefix.value
-    
+
     def __neg__(self) -> "Prefixed":
         return Prefixed.new(-self.number, self.prefix)
+
+    def __abs__(self) -> "Prefixed":
+        return Prefixed.new(abs(self.number), self.prefix)
 
     def __mul__(self, other) -> "Prefixed":
         if isinstance(other, Prefixed):
@@ -225,7 +231,7 @@ class Prefixed(BaseModel):
         elif not isinstance(other, (str, int, float, Decimal)):
             return NotImplemented
         elif float(other) == 0.0:
-            return float('inf')
+            return float("inf")
         return Prefixed.new(self.number / Decimal(str(other)), self.prefix).scale()
 
     def __rtruediv__(self, other) -> "Prefixed":
@@ -234,7 +240,7 @@ class Prefixed(BaseModel):
         elif not isinstance(other, (str, int, float, Decimal)):
             return NotImplemented
         elif float(self.number) == 0.0:
-            return float('inf')
+            return float("inf")
         return Prefixed.new(Decimal(str(other)) / self.number, self.prefix).scale()
 
     def __pow__(self, other) -> "Prefixed":

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -201,6 +201,9 @@ class Prefixed(BaseModel):
     def __float__(self) -> float:
         """Convert to float"""
         return float(self.number) * 10**self.prefix.value
+    
+    def __neg__(self) -> "Prefixed":
+        return Prefixed.new(-self.number, self.prefix)
 
     def __mul__(self, other) -> "Prefixed":
         if isinstance(other, Prefixed):
@@ -221,6 +224,8 @@ class Prefixed(BaseModel):
             return ((self.number / other.number) * (self.prefix / other.prefix)).scale()
         elif not isinstance(other, (str, int, float, Decimal)):
             return NotImplemented
+        elif float(other) == 0.0:
+            return float('inf')
         return Prefixed.new(self.number / Decimal(str(other)), self.prefix).scale()
 
     def __rtruediv__(self, other) -> "Prefixed":
@@ -228,6 +233,8 @@ class Prefixed(BaseModel):
             return ((self.number / other.number) * (self.prefix / other.prefix)).scale()
         elif not isinstance(other, (str, int, float, Decimal)):
             return NotImplemented
+        elif float(self.number) == 0.0:
+            return float('inf')
         return Prefixed.new(Decimal(str(other)) / self.number, self.prefix).scale()
 
     def __pow__(self, other) -> "Prefixed":

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -119,7 +119,7 @@ class Prefix(Enum):
         return NotImplemented
 
     def __int__(self):
-        return 10**self.value
+        return int(10**self.value)
 
     def __float__(self):
         return float(10**self.value)
@@ -293,6 +293,9 @@ class Prefixed(BaseModel):
         else:
             newpref = Prefix.closest(abs(self.number).log10() + self.prefix.value)
             return self.scale(newpref)
+
+    def __str__(self) -> str:
+        return f"{self.number}*{self.prefix.name}"
 
     def __repr__(self) -> str:
         return f"{self.number}*{self.prefix.name}"
@@ -521,3 +524,4 @@ def e(exp: Any) -> Exponent:
 # Star-imports *do not* include the single-character names `µ`, `e`, et al.
 # They can be explicityle imported from `hdl21.prefix` instead.
 __all__ = ["Prefix", "Prefixed", "Exponent"]
+

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -524,4 +524,3 @@ def e(exp: Any) -> Exponent:
 # Star-imports *do not* include the single-character names `µ`, `e`, et al.
 # They can be explicityle imported from `hdl21.prefix` instead.
 __all__ = ["Prefix", "Prefixed", "Exponent"]
-

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -115,6 +115,15 @@ class Prefix(Enum):
 
         return NotImplemented
 
+    def __int__(self):
+        return 10**self.value
+
+    def __float__(self):
+        return float(10**self.value)
+
+    def __str__(self):
+        return str(Decimal(10) ** self.value)
+
 
 """
 # Note on Numeric Types 
@@ -231,9 +240,9 @@ class Prefixed(BaseModel):
     def __rpow__(self, other) -> "Prefixed":
         if not isinstance(other, (str, int, float, Decimal)):
             return NotImplemented
-        return (
-            Decimal(str(other)) ** (self.number * (Decimal(10) ** self.prefix))
-        ).scale()
+        return Prefixed.new(
+            Decimal(str(other)) ** (self.number * (Decimal(str(self.prefix))))
+        )
 
     def __add__(self, other: "Prefixed") -> "Prefixed":
         if not isinstance(other, (str, int, float, Decimal, Prefixed)):
@@ -466,6 +475,12 @@ class Exponent:
 
     def __repr__(self) -> str:
         return f"e({self.symbol.value+self.residual})"
+
+    def __float__(self) -> float:
+        return float(10 ** (self.symbol.value + self.residual))
+
+    def __str__(self) -> str:
+        return str(Decimal(10) ** (self.symbol.value + self.residual))
 
 
 def e(exp: Any) -> Exponent:

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -232,7 +232,9 @@ class Prefixed(BaseModel):
             return NotImplemented
         elif float(other) == 0.0:
             return float("inf")
-        return Prefixed.new(self.number / Decimal(str(other)), self.prefix).scale()
+        return Prefixed.new(
+            self.number / Decimal(str(other)), self.prefix.value
+        ).scale()
 
     def __rtruediv__(self, other) -> "Prefixed":
         if isinstance(other, Prefixed):
@@ -241,7 +243,9 @@ class Prefixed(BaseModel):
             return NotImplemented
         elif float(self.number) == 0.0:
             return float("inf")
-        return Prefixed.new(Decimal(str(other)) / self.number, self.prefix).scale()
+        return Prefixed.new(
+            Decimal(str(other)) / self.number, -self.prefix.value
+        ).scale()
 
     def __pow__(self, other) -> "Prefixed":
         if not isinstance(other, (str, int, float, Decimal)):
@@ -254,7 +258,8 @@ class Prefixed(BaseModel):
         if not isinstance(other, (str, int, float, Decimal)):
             return NotImplemented
         return Prefixed.new(
-            Decimal(str(other)) ** (self.number * (Decimal(str(self.prefix))))
+            Decimal(str(other))
+            ** (self.number * (10 ** Decimal(str(self.prefix.value))))
         )
 
     def __add__(self, other: "Prefixed") -> "Prefixed":
@@ -282,8 +287,8 @@ class Prefixed(BaseModel):
         if not isinstance(other, (str, int, float, Decimal, Prefixed)):
             return NotImplemented
         elif not isinstance(other, Prefixed):
-            return _subtract(lhs=self, rhs=Prefixed.new(other))
-        return _subtract(lhs=self, rhs=other).scale()
+            return _subtract(lhs=Prefixed.new(other), rhs=self)
+        return _subtract(lhs=other, rhs=self).scale()
 
     def scale(self, prefix: Prefix = None) -> "Prefixed":
         """Scale to a new `Prefix`"""
@@ -399,6 +404,7 @@ m = MILLI = Prefix.MILLI
 c = CENTI = Prefix.CENTI
 d = DECI = Prefix.DECI
 D = DECA = Prefix.DECA
+H = HECTO = Prefix.HECTO
 K = KILO = Prefix.KILO
 M = MEGA = Prefix.MEGA
 G = GIGA = Prefix.GIGA

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -5,7 +5,6 @@ from pydantic.dataclasses import dataclass
 
 import hdl21 as h
 
-
 def test_decimal():
     """This isnt a test of Hdl21 so much as a demo and reminder of how
     the standard library's `Decimal` works, particularly in conjunction with
@@ -132,6 +131,7 @@ def test_prefixed_mul():
 
 
 def test_prefixed_div():
+
     """Test `Prefixed` True Division"""
     from hdl21.prefix import e
 
@@ -336,7 +336,7 @@ def test_prefix_comparison():
     assert (2 * e(1 / 3)) ** 2 == 4 * e(2 / 3)
 
 
-def test_prefix_conversion():
+def test_prefixed_conversion():
     """Test types that can be converted to `Prefixed`'s internal `Decimal`."""
     from hdl21.prefix import e, y
 
@@ -353,6 +353,14 @@ def test_prefix_conversion():
     assert type(int(2 * e(2))) == int
     assert int(2 * e(2)) == 200
 
+def test_prefix_conversion():
+    """Test types that can be converted to `Prefix`'s internal `Decimal`."""
+    from hdl21.prefix import m,M
+
+    assert int(m) == 0
+    assert float(m) == 0.001
+    assert int(M) == 1e6
+    assert float(M) == 1e6
 
 def test_unit_prefix():
     """Test the UNIT prefix"""
@@ -402,6 +410,49 @@ def test_not_implemented_prefixed():
     with pt.raises(TypeError):
         assert type([] ** (1 * e(4))) == NotImplemented
 
+def test_to_prefixed():
+    from hdl21.prefix import to_prefixed
+
+    assert to_prefixed(1) == h.Prefixed.new(1)
+    assert to_prefixed(1.0) == h.Prefixed.new(1.0)
+    assert to_prefixed(Decimal(1)) == h.Prefixed.new(Decimal(1))
+    assert to_prefixed(1 * h.Prefix.KILO) == h.Prefixed.new(1, h.Prefix.KILO)
+    # with pt.raises(RuntimeError):
+    #     assert to_prefixed([]) == NotImplemented
+
+def test_exponent_conversions():
+
+    from hdl21.prefix import e
+
+    assert e(1).__repr__() == "e(1)"
+    assert e(1).__str__() == "10"
+    assert e(1).__float__() == 10.0
+
+def test_prefixed_conversion():
+
+    from hdl21.prefix import n
+
+    assert (1*n).__repr__() == "1*NANO"
+    assert (1*n).__str__() == "1*NANO"
+    assert (1*n).__float__() == 1e-9
+
+def test_prefixed_abs():
+
+    from hdl21.prefix import n
+
+    assert abs(-1*n) == 1*n
+
+def test_prefixed_neg():
+
+    from hdl21.prefix import n
+
+    assert -(1*n) == -1*n
+
+def test_prefixed_divzero():
+
+    from hdl21.prefix import n
+
+    assert 1*n / 0 == float('inf')
 
 def test_not_implemented_exponent():
     from hdl21.prefix import Exponent, K, e

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -128,6 +128,7 @@ def test_prefixed_mul():
     assert (1 * e(1)) * (1 * e(2)) == 1 * e(3)
     assert 2 * (1 * e(2)) == 2 * e(2)
     assert (1 * e(2)) * 2 == 2 * e(2)
+    assert (1 * e(2)) * 2.0 == 2.0 * e(2)
 
 
 def test_prefixed_div():
@@ -136,6 +137,8 @@ def test_prefixed_div():
 
     assert (1 * e(0)) / 2 == 0.5 * e(0)
     assert (1 * e(0)) / (2 * e(0)) == 0.5 * e(0)
+    assert 2 / (1 * e(0)) == 2 * e(0)
+    assert 6 / (3 * e(0)) == 2 * e(0)
 
 
 def test_prefixed_pow():
@@ -144,6 +147,11 @@ def test_prefixed_pow():
 
     assert (1 * e(1)) ** 2 == 1 * e(2)
     assert (2 * e(-2)) ** 2 == 4 * e(-4)
+
+    # Test with __rpow__
+    assert 2 ** (2 * e(0)) == 4 * e(0)
+    assert 2.0 ** (2 * e(0)) == 4 * e(0)
+    assert Decimal(2) ** (2 * e(0)) == 4 * e(0)
 
 
 def test_prefixed_addition():
@@ -159,6 +167,14 @@ def test_prefixed_addition():
     assert (1 * e(0)) + (1 * e(-2)) == 1.01 * e(0)
     assert (1 * e(2)) + (1 * e(0)) == 1.01 * e(2)
 
+    # Addition with other types:
+    assert (1 * e(0)) + 1 == 2 * e(0)
+    assert 1 + (1 * e(0)) == 2 * e(0)
+    assert (1 * e(0)) + 1.0 == 2.0 * e(0)
+    assert 1.0 + (1 * e(0)) == 2.0 * e(0)
+    assert (1 * e(0)) + Decimal(1) == 2.0 * e(0)
+    assert Decimal(1) + (1 * e(0)) == 2.0 * e(0)
+
 
 def test_prefixed_subtraction():
     """Test `Prefixed` Subtraction"""
@@ -172,6 +188,14 @@ def test_prefixed_subtraction():
     assert (1 * e(0)) - (1 * e(0)) == 0.0 * e(1)
     assert (1 * e(0)) - (1 * e(-2)) == 0.99 * e(0)
     assert (1 * e(2)) - (1 * e(0)) == 0.99 * e(2)
+
+    # Subtraction with other types:
+    assert (1 * e(0)) - 1 == 0 * e(0)
+    assert 1 - (1 * e(0)) == 0 * e(0)
+    assert (1 * e(0)) - 1.0 == 0.0 * e(0)
+    assert 1.0 - (1 * e(0)) == 0.0 * e(0)
+    assert (1 * e(0)) - Decimal(1) == 0.0 * e(0)
+    assert Decimal(1) - (1 * e(0)) == 0.0 * e(0)
 
 
 def test_e():
@@ -216,6 +240,13 @@ def test_e_mult():
     assert 1 * e(-0.123) * e(0.003) * e(0.1) == 1 * e(-0.02)
     assert 11 * e(0.123) * e(0.123) * e(0.123) == 11 * e(0.369)
     assert 1 * e(0.123) * e(-0.123) == 1 * e(0)
+
+    # Test __mul__
+    assert e(-9) * 11 == h.Prefixed.new(11, h.Prefix.NANO)
+    assert e(1.5) * e(4.5) * 11 == 11 * e(6)
+    assert e(1) * e(-1) * 11 == 11 * e(0)
+    assert e(1) * e(-2) * e(3) * 11 == 11 * e(2)
+    assert e(-0.5) * e(1) * 1 == 1 * e(0.5)
 
 
 def test_e_pow():

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -382,21 +382,25 @@ def test_not_implemented_prefixed():
     from hdl21.prefix import e
 
     with pt.raises(TypeError):
+        assert type((1 * e(1)) + []) == NotImplemented
+    with pt.raises(TypeError):
+        assert type([] + (1 * e(1))) == NotImplemented
+    with pt.raises(TypeError):
+        assert type((1 * e(1)) - []) == NotImplemented
+    with pt.raises(TypeError):
+        assert type([] - (1 * e(1))) == NotImplemented
+    with pt.raises(TypeError):
         assert type([] * (2 * e(1))) == NotImplemented
     with pt.raises(TypeError):
         assert type((2 * e(2)) * []) == NotImplemented
     with pt.raises(TypeError):
         assert type((1 * e(0)) / []) == NotImplemented
     with pt.raises(TypeError):
+        assert type([] / (1 * e(0))) == NotImplemented
+    with pt.raises(TypeError):
         assert type((1 * e(4)) ** []) == NotImplemented
     with pt.raises(TypeError):
-        assert type(1 + (1 * e(0))) == NotImplemented
-    with pt.raises(TypeError):
-        assert type((1 * e(0)) + 1) == NotImplemented
-    with pt.raises(TypeError):
-        assert type(1 - (1 * e(0))) == NotImplemented
-    with pt.raises(TypeError):
-        assert type((1 * e(0)) - 1) == NotImplemented
+        assert type([] ** (1 * e(4))) == NotImplemented
 
 
 def test_not_implemented_exponent():

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -5,6 +5,7 @@ from pydantic.dataclasses import dataclass
 
 import hdl21 as h
 
+
 def test_decimal():
     """This isnt a test of Hdl21 so much as a demo and reminder of how
     the standard library's `Decimal` works, particularly in conjunction with
@@ -353,14 +354,16 @@ def test_prefixed_conversion():
     assert type(int(2 * e(2))) == int
     assert int(2 * e(2)) == 200
 
+
 def test_prefix_conversion():
     """Test types that can be converted to `Prefix`'s internal `Decimal`."""
-    from hdl21.prefix import m,M
+    from hdl21.prefix import m, M
 
     assert int(m) == 0
     assert float(m) == 0.001
     assert int(M) == 1e6
     assert float(M) == 1e6
+
 
 def test_unit_prefix():
     """Test the UNIT prefix"""
@@ -410,6 +413,7 @@ def test_not_implemented_prefixed():
     with pt.raises(TypeError):
         assert type([] ** (1 * e(4))) == NotImplemented
 
+
 def test_to_prefixed():
     from hdl21.prefix import to_prefixed
 
@@ -420,6 +424,7 @@ def test_to_prefixed():
     # with pt.raises(RuntimeError):
     #     assert to_prefixed([]) == NotImplemented
 
+
 def test_exponent_conversions():
 
     from hdl21.prefix import e
@@ -428,31 +433,36 @@ def test_exponent_conversions():
     assert e(1).__str__() == "10"
     assert e(1).__float__() == 10.0
 
+
 def test_prefixed_conversion():
 
     from hdl21.prefix import n
 
-    assert (1*n).__repr__() == "1*NANO"
-    assert (1*n).__str__() == "1*NANO"
-    assert (1*n).__float__() == 1e-9
+    assert (1 * n).__repr__() == "1*NANO"
+    assert (1 * n).__str__() == "1*NANO"
+    assert (1 * n).__float__() == 1e-9
+
 
 def test_prefixed_abs():
 
     from hdl21.prefix import n
 
-    assert abs(-1*n) == 1*n
+    assert abs(-1 * n) == 1 * n
+
 
 def test_prefixed_neg():
 
     from hdl21.prefix import n
 
-    assert -(1*n) == -1*n
+    assert -(1 * n) == -1 * n
+
 
 def test_prefixed_divzero():
 
     from hdl21.prefix import n
 
-    assert 1*n / 0 == float('inf')
+    assert 1 * n / 0 == float("inf")
+
 
 def test_not_implemented_exponent():
     from hdl21.prefix import Exponent, K, e


### PR DESCRIPTION
Notice that I couldn't do things like `1 + (1 * UNIT)`, so I decided to iron everything out so that all `Prefixed` gets along with other common numerical types, so all operations should work and return the correct `Prefixed` answer:

- `Prefixed + other`
- `other + Prefixed`
- `Prefixed - other`
- `other - Prefixed`
- `Prefixed * other`
- `other * Prefixed`
- `Prefixed / other`
- `other / Prefixed`
- `Prefixed ** other`
- `other ** Prefixed`

`Exponent` arithmetic could also be improved but I'm not sure exactly when `e(3) - 500 = e(2.69897000434)` would ever be relevant, if just to have perfectly round corners.