### PR TITLE
FIX: Pydantic v2 patch upgrade

### DIFF
--- a/hdl21/__init__.py
+++ b/hdl21/__init__.py
@@ -7,7 +7,7 @@ __version__ = "4.0.0"  # NOTE: VLSIR_VERSION
 
 # Before any real importing, ensure we can instantiate non-pydantic types in type-checked dataclasses.
 # This `Config` seems to be shared for *all* pydantic types, even when not applied to `BaseModel`.
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 BaseModel.Config.arbitrary_types_allowed = True
 

--- a/hdl21/call.py
+++ b/hdl21/call.py
@@ -7,7 +7,7 @@ If both were provided, fail.
 """
 
 from typing import Union, Any, Dict
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 # Local Imports
 from .default import Default

--- a/hdl21/datatype.py
+++ b/hdl21/datatype.py
@@ -1,7 +1,7 @@
 """ 
 # Datatypes Decorator 
 
-Wraps `@pydantic.dataclasses.dataclass` so that we can make forward type-references 
+Wraps `@pydantic.v1.dataclasses.dataclass` so that we can make forward type-references
 throughout the package, and then sort them all out at the end of import-time. 
 
 The intended usage is such that `__init__.py` includes
@@ -23,12 +23,12 @@ Notes:
   * Importing this function into other packages is therefore highly discouraged. (Copying it is quite easy though.) 
 * `@datatype` only works on modules which are imported before `_update_forward_refs()` is run. 
   * Generally this means modules which are imported as part of `__init__.py`
-* `@datatype` is designed solely to work on `pydantic.dataclasses.dataclass`es. 
+* `@datatype` is designed solely to work on `pydantic.v1.dataclasses.dataclass`es.
   * Notable exceptions include *union types* thereof, which do not have the necessary fields/ methods. 
 """
 
-from pydantic import Extra
-from pydantic.dataclasses import dataclass
+from pydantic.v1 import Extra
+from pydantic.v1.dataclasses import dataclass
 from typing import TypeVar, Type, Any
 
 # The list of defined datatypes

--- a/hdl21/elab/elaborators/conntypes.py
+++ b/hdl21/elab/elaborators/conntypes.py
@@ -7,7 +7,7 @@ import copy
 from typing import Any, Union, Dict
 
 # PyPi Imports
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Local imports
 from ...connect import is_connectable, Connectable

--- a/hdl21/elab/elaborators/flatten_bundles.py
+++ b/hdl21/elab/elaborators/flatten_bundles.py
@@ -8,7 +8,7 @@ from dataclasses import field
 from typing import Dict, List, Union, Optional
 
 # PyPi
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Local imports
 from ...module import Module

--- a/hdl21/external_module.py
+++ b/hdl21/external_module.py
@@ -5,7 +5,7 @@ Wrapper for circuits defined outside Hdl21.
 """
 
 from typing import Any, Optional, List, Type, Dict
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # VLSIR Imports
 from vlsirtools import SpiceType

--- a/hdl21/literal.py
+++ b/hdl21/literal.py
@@ -1,5 +1,5 @@
 # PyPi Imports
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/hdl21/params.py
+++ b/hdl21/params.py
@@ -7,7 +7,7 @@ import dataclasses, inspect, json, hashlib
 from typing import Optional, Any, Type, TypeVar, Dict
 
 # PyPi Imports
-import pydantic
+import pydantic.v1
 
 # Local Imports
 from .default import Default
@@ -116,7 +116,7 @@ def paramclass(cls: Type[T]) -> Type[T]:
     cls.defaults = classmethod(defaults)
 
     # Pass this through the pydantic dataclass-decorator-function
-    cls = pydantic.dataclasses.dataclass(cls, config=Config, frozen=True)
+    cls = pydantic.v1.dataclasses.dataclass(cls, config=Config, frozen=True)
 
     # Pydantic seems to want to add this one *after* class-creation
     def _brick_subclassing_(cls, *_, **__):
@@ -156,10 +156,10 @@ def isparamclass(cls: type) -> bool:
 
 
 class Config:  # Pydantic Model Config
-    allow_extra = pydantic.Extra.forbid
+    allow_extra = pydantic.v1.Extra.forbid
 
 
-@pydantic.dataclasses.dataclass(config=Config, frozen=True)
+@pydantic.v1.dataclasses.dataclass(config=Config, frozen=True)
 class Param:
     """# Parameter Declaration"""
 
@@ -221,9 +221,9 @@ def _unique_name(params: Any) -> str:
 def hdl21_naming_encoder(obj: Any) -> Any:
     """JSON encoder for naming of Hdl21 parameter-values.
 
-    "Extends" `pydantic.json.pydantic_encoder` by first checking for
+    "Extends" `pydantic.v1.json.pydantic_encoder` by first checking for
     each of the non-serializable Hdl21 types (`Module`, `Instance`, `Generator`, etc.),
-    then hands everything else off to `pydantic.json.pydantic_encoder`.
+    then hands everything else off to `pydantic.v1.json.pydantic_encoder`.
 
     Note this *does not fully serialize `Module`s and the like -
     see `hdl21.to_proto` for this. This JSON-ization is just good enough
@@ -263,7 +263,7 @@ def hdl21_naming_encoder(obj: Any) -> Any:
         return {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj)}
 
     # Not an Hdl21 type. Hand off to pydantic.
-    return pydantic.json.pydantic_encoder(obj)
+    return pydantic.v1.json.pydantic_encoder(obj)
 
 
 # Shortcut for parameter-less generators.

--- a/hdl21/pdk/corner.py
+++ b/hdl21/pdk/corner.py
@@ -3,7 +3,7 @@
 """
 
 from enum import Enum, auto
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 
 class Corner(Enum):

--- a/hdl21/pdk/installation.py
+++ b/hdl21/pdk/installation.py
@@ -52,7 +52,7 @@ sim.run()
 
 """
 
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 
 @dataclass
@@ -68,14 +68,14 @@ class PdkInstallation:
     e.g. compilation settings for a particular tool, or metadata indicating
     relevant tool versions.
 
-    Most PDK modules should generally create a `pydantic.dataclass` which is also
+    Most PDK modules should generally create a `pydantic.v1.dataclass` which is also
     a sub-class of `PdkInstallation`, e.g.
 
     ```python
     # mypdk.py
 
     from pathlib import Path
-    from pydantic.dataclasses import dataclass
+    from pydantic.v1.dataclasses import dataclass
     from hdl21.pdk import PdkInstallation
 
     @dataclass

--- a/hdl21/pdk/sample_pdk/pdk.py
+++ b/hdl21/pdk/sample_pdk/pdk.py
@@ -23,7 +23,7 @@ import copy
 from pathlib import Path
 
 # PyPi Imports
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Project Imports
 import hdl21 as h

--- a/hdl21/prefix.py
+++ b/hdl21/prefix.py
@@ -18,8 +18,8 @@ with the multiplication operator, to construct values such as `11 * e(-21)`.
 from enum import Enum
 from decimal import Decimal
 from typing import Optional, Any, Union, Tuple
-from pydantic import BaseModel, ValidationError, Field
-from pydantic.dataclasses import dataclass
+from pydantic.v1 import BaseModel, ValidationError, Field
+from pydantic.v1.dataclasses import dataclass
 
 
 EPSILON = 20

--- a/hdl21/primitives.py
+++ b/hdl21/primitives.py
@@ -66,7 +66,7 @@ from dataclasses import replace
 from typing import Optional, Any, List, Type, Dict
 
 # PyPi Imports
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Local imports
 from .default import Default

--- a/hdl21/proto/exporting.py
+++ b/hdl21/proto/exporting.py
@@ -16,7 +16,7 @@ from dataclasses import fields
 from enum import Enum
 from typing import Optional, List, Union, Dict, Any
 
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Local imports
 # Proto-definitions

--- a/hdl21/scalar.py
+++ b/hdl21/scalar.py
@@ -1,6 +1,6 @@
 from typing import Union
 from decimal import Decimal
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 # Local Imports
 from .prefix import Prefixed

--- a/hdl21/source_info.py
+++ b/hdl21/source_info.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from types import ModuleType, FrameType
 from typing import Optional, Set
 
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 
 @dataclass

--- a/hdl21/tests/test_params.py
+++ b/hdl21/tests/test_params.py
@@ -6,8 +6,8 @@
 import pytest
 from dataclasses import field, FrozenInstanceError
 
-from pydantic import ValidationError
-from pydantic.dataclasses import dataclass
+from pydantic.v1 import ValidationError
+from pydantic.v1.dataclasses import dataclass
 
 # Import the PUT (package under test)
 import hdl21 as h

--- a/hdl21/tests/test_prefix.py
+++ b/hdl21/tests/test_prefix.py
@@ -1,7 +1,7 @@
 import pytest as pt
 from decimal import Decimal
-from pydantic import ValidationError
-from pydantic.dataclasses import dataclass
+from pydantic.v1 import ValidationError
+from pydantic.v1.dataclasses import dataclass
 
 import hdl21 as h
 

--- a/pdks/Asap7/asap7_hdl21/pdk.py
+++ b/pdks/Asap7/asap7_hdl21/pdk.py
@@ -17,7 +17,7 @@ from typing import Union, Optional
 from types import SimpleNamespace
 from dataclasses import asdict
 
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 import hdl21 as h
 from hdl21.pdk import PdkInstallation

--- a/pdks/Gf180/gf180_hdl21/pdk_data.py
+++ b/pdks/Gf180/gf180_hdl21/pdk_data.py
@@ -23,7 +23,7 @@ from typing import Dict, Tuple, Optional, List, Any
 from types import SimpleNamespace
 
 # PyPi Imports
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Hdl21 Imports
 import hdl21 as h

--- a/pdks/PdkTemplate/{{cookiecutter.repo_name}}/setup.py
+++ b/pdks/PdkTemplate/{{cookiecutter.repo_name}}/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.7",
     install_requires=[
-        "pydantic>=1.9.0",
+        "pydantic>=2",
         f"hdl21=={_VLSIR_VERSION}",
     ],
     extras_require={"dev": ["pytest==7.1", "coverage", "pytest-cov", "twine"]},

--- a/pdks/PdkTemplate/{{cookiecutter.repo_name}}/{{cookiecutter.pdk_name}}/pdk.py
+++ b/pdks/PdkTemplate/{{cookiecutter.repo_name}}/{{cookiecutter.pdk_name}}/pdk.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from dataclasses import field
 
 # PyPi Imports
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Hdl21 Imports
 import hdl21 as h

--- a/pdks/Sky130/sky130_hdl21/pdk_data.py
+++ b/pdks/Sky130/sky130_hdl21/pdk_data.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple, List
 from types import SimpleNamespace
 
 # PyPi Imports
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Hdl21 Imports
 import hdl21 as h

--- a/pdks/Sky130/sky130_hdl21/pdk_logic.py
+++ b/pdks/Sky130/sky130_hdl21/pdk_logic.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Dict, Optional, Any
 
 # PyPi Imports
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 # Hdl21 Imports
 import hdl21 as h

--- a/scripts/primtable.py
+++ b/scripts/primtable.py
@@ -6,7 +6,7 @@ Writes the markdown-format table of primitives used in documentation.
 
 # import sys
 # from typing import IO
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 from hdl21.primitives import _primitives, PrimLibEntry
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         f"vlsirtools=={_VLSIR_VERSION}",
         # Our primary external dependency is pydantic.
         # Tested with everything in the 1.9-1.10 range.
-        "pydantic>=1.9.0,<1.11",
+        "pydantic>=2",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Hi Dan,

Hope you are well!

`hdl21` is conflicting with some other packages that have updated to `pydantic v2`. I've tried to do the proper migration, only to realise it is quite involved and will take me far longer than I can.

However, instead, what I have done in this PR is to do the patch migration where everything stays compatible to the original version using the `pydantic.v1` submodule they provide. This makes the migration much easier and can be progressively implemented if required. 

This is still a draft because when I ran the pytest I got this:

```
>       return vlsir.Prefixed(string_value=str(pref.number), prefix=prefix)
E       ValueError: Protocol message Prefixed has no "string_value" field.

hdl21\proto\exporting.py:434: ValueError
======================================================================================================= short test summary info =======================================================================================================
FAILED examples/test_examples.py::test_ro - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED examples/test_examples.py::test_rdac - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED examples/test_examples.py::test_diff_ota - ValueError: Protocol message ParamValue has no "int64_value" field.
FAILED examples/test_examples.py::test_idac - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/pdk/sample_pdk/test_sample_pdk.py::test_netlist - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/sim/tests/test_sim.py::test_sim2 - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/sim/tests/test_sim.py::test_simattrs - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/sim/tests/test_sim.py::test_sim_decorator - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/sim/tests/test_sim.py::test_proto1 - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/sim/tests/test_sim.py::test_delay1 - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/tests/test_builtin_generators.py::test_mos_generator - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/tests/test_exports.py::test_prim_proto1 - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/tests/test_exports.py::test_ideal_primitives - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/tests/test_exports.py::test_spice_netlister - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED hdl21/tests/test_exports.py::test_roundtrip_external_module - ValueError: Protocol message ParamValue has no "int64_value" field.
FAILED pdks/Gf180/gf180_hdl21/test_netlists.py::test_xtor_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Gf180/gf180_hdl21/test_netlists.py::test_2_term_res_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Gf180/gf180_hdl21/test_netlists.py::test_3_term_res_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Gf180/gf180_hdl21/test_netlists.py::test_diode_netlists - ValueError: Protocol message Prefixed has no "string_value" field.
FAILED pdks/Gf180/gf180_hdl21/test_netlists.py::test_3T_bjt_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Gf180/gf180_hdl21/test_netlists.py::test_4T_bjt_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Gf180/gf180_hdl21/test_netlists.py::test_cap_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Gf180/gf180_hdl21/test_pdk.py::test_netlist - ValueError: Protocol message Prefixed has no "string_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_netlists.py::test_xtor_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_netlists.py::test_2_term_res_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_netlists.py::test_3_term_res_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_netlists.py::test_diode_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_netlists.py::test_pnp_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_netlists.py::test_npn_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_netlists.py::test_mim_cap_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_netlists.py::test_var_cap_netlists - ValueError: Protocol message Prefixed has no "int64_value" field.
FAILED pdks/Sky130/sky130_hdl21/test_pdk.py::test_netlist - ValueError: Protocol message Prefixed has no "string_value" field.
======================================================================================== 32 failed, 180 passed, 4 skipped, 5 xfailed in 3.69s ==================================
```

However, as far as I can tell, these are all issues in `vlsirtools` when tested from hdl21. The latest github versions are straightup incompatible, so this is when using `vlsirtools==4.0.0` release.

What do you think? I'm going to try to keep debugging to get the tests to pas. They're all related to `int64_value` fields so maybe that makes some sense to you. It'd be nice to have a patch release of this in pypi when we get tests to pass so that hdl21 can be used in a compatible environment with the other pydantic v2 tools.

Re https://github.com/dan-fritchman/Hdl21/issues/157 and maybe https://github.com/dan-fritchman/Hdl21/issues/174