### PR TITLE
update pydantic

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        pydantic-version: ["==1.9.0", "==2.0", "==2.6", ""]
+        pydantic-version: ["==1.9.0", "==2.0", "==2.10", ""]
         dep-installer: ["dev", "pypi"]
     # Issues for these:
     # VLSIR/ PyPi: https://github.com/dan-fritchman/Hdl21/issues/216

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ dependencies = [
   "vlsir>=7.0.0",      # VLSIR_VERSION
   "vlsirtools>=7.0.0", # VLSIR_VERSION
   "pydantic>=1.9.0,<3",
+  "typing-extensions"
+
 ]
 requires-python = ">=3.7, <3.13"
 maintainers = [{ name = "Dan Fritchman", email = "dan@fritch.mn" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "7.0.0" # VLSIR_VERSION
 dependencies = [
   "vlsir>=7.0.0",      # VLSIR_VERSION
   "vlsirtools>=7.0.0", # VLSIR_VERSION
-  "pydantic>=1.9.0,<2.7",
+  "pydantic>=1.9.0,<3",
 ]
 requires-python = ">=3.7, <3.13"
 maintainers = [{ name = "Dan Fritchman", email = "dan@fritch.mn" }]


### PR DESCRIPTION
The latest version of GDSFactory requires newer versions of pydantic that make not interoperable with hdl21

this PR allows to install hdl21 with later versions of pydantic